### PR TITLE
Pass func argument to expected_integrated_grad function in _explainer_tf.py

### DIFF
--- a/src/crested/tl/_explainer_tf.py
+++ b/src/crested/tl/_explainer_tf.py
@@ -175,7 +175,7 @@ def expected_integrated_grad(
                 baseline,
                 num_steps=num_steps,
                 class_index=class_index,
-                func=tf.math.reduce_mean,
+                func=func,
             )
         )
     return np.mean(np.array(grads), axis=0)


### PR DESCRIPTION
Small bug fix

the func argument was not passed to the `expected_integrated_grad` in `_explainer_tf.py`