### PR TITLE
improve correlation correlation speed

### DIFF
--- a/src/crested/pl/heatmap/_correlations.py
+++ b/src/crested/pl/heatmap/_correlations.py
@@ -73,12 +73,7 @@ def correlations_self(
     if log_transform:
         x = np.log1p(x)
 
-    n_features = x.shape[0]
-
-    correlation_matrix = np.zeros((n_features, n_features))
-    for i in range(n_features):
-        for j in range(n_features):
-            correlation_matrix[i, j] = np.corrcoef(x[i, :], x[j, :])[0, 1]
+    correlation_matrix = np.corrcoef(x)
 
     fig = _generate_heatmap(correlation_matrix, classes, vmin, vmax)
 

--- a/src/crested/pl/heatmap/_correlations.py
+++ b/src/crested/pl/heatmap/_correlations.py
@@ -182,10 +182,14 @@ def correlations_predictions(
         axes = [axes]
 
     for ax, (model_name, y) in zip(axes, predicted_values.items()):
-        correlation_matrix = np.zeros((n_features, n_features))
-        for i in range(n_features):
-            for j in range(n_features):
-                correlation_matrix[i, j] = np.corrcoef(x[i, :], y[j, :])[0, 1]
+        # this is the same as
+        # c = np.corrcoef(np.vstack([x, y]))
+        # so c[0, 0] in the old funciton would correspond to
+        # c[0, x.shape[0]] in this new function
+        correlation_matrix = np.corrcoef(x, y)
+        # reformat the array to only get correlations between x and y
+        # and no self correlations
+        correlation_matrix = np.hsplit(np.vsplit(correlation_matrix, 2)[1], 2)[0].T
 
         sns.heatmap(
             correlation_matrix,

--- a/src/crested/pl/heatmap/_correlations.py
+++ b/src/crested/pl/heatmap/_correlations.py
@@ -175,7 +175,6 @@ def correlations_predictions(
             predicted_values[key] = np.log1p(predicted_values[key])
 
     n_models = len(predicted_values)
-    n_features = x.shape[0]
 
     fig, axes = plt.subplots(1, n_models, sharey=False)
     if n_models == 1:


### PR DESCRIPTION
- **Improve correlations_self computation time**

```python
rng = np.random.default_rng(seed = 123)
x = rng.random((100, 200))

def old(X):
    c = np.zeros((X.shape[0], X.shape[0]))
    for i in range(X.shape[0]):
        for j in range(X.shape[0]):
            c[i, j] = np.corrcoef(X[i, :], X[j, :])[0, 1]
    return c

def new(X):
    c = np.corrcoef(X)
    return c

%time a = old(x)

CPU times: user 388 ms, sys: 925 μs, total: 389 ms
Wall time: 389 ms

%time b = new(x)

CPU times: user 351 μs, sys: 0 ns, total: 351 μs
Wall time: 321 μs

np.allclose(a, b)
True

```


- **Improve correlation_predictions speed**

```python

rng = np.random.default_rng(seed = 123)
x = rng.random((100, 200))
y = rng.random((100, 200))

def old(X, Y):
    c = np.zeros((X.shape[0], X.shape[0]))
    for i in range(X.shape[0]):
        for j in range(X.shape[0]):
            c[i, j] = np.corrcoef(X[i, :], Y[j, :])[0, 1]
    return c

def new(X, Y):
    # this is the same as
    # c = np.corrcoef(np.vstack([X, Y]))
    # so c[0, 0] in the old funciton would correspond to
    # c[0, x.shape[0]] in this new function
    c = np.corrcoef(X, Y)
    # reformat the array to only get correlations between X and Y
    # and no self correlations
    return np.hsplit(np.vsplit(c, 2)[1], 2)[0].T

%time a = old(x, y)
%time a = old(x, y)
CPU times: user 391 ms, sys: 895 μs, total: 392 ms
Wall time: 391 ms

%time b = new(x, y)
CPU times: user 2.76 ms, sys: 25 μs, total: 2.79 ms
Wall time: 790 μs

np.allclose(a, b)
True

```
