### PR TITLE
Return figure after rendering modisco_results plot.

### DIFF
--- a/src/crested/pl/patterns/_modisco_results.py
+++ b/src/crested/pl/patterns/_modisco_results.py
@@ -291,7 +291,7 @@ def modisco_results(
     if "height" not in kwargs:
         kwargs["height"] = 2 * max_num_patterns
 
-    render_plot(fig, **kwargs)
+    return render_plot(fig, **kwargs)
 
 
 def plot_custom_xticklabels(


### PR DESCRIPTION
```python

render_plot(fig, **kwargs)

```

should be returned at the end of the function (so the created figure can be manipulated).
This is the case for all functions, except `crested.pl.patterns.modisco_result.`
