### PR TITLE
Remove pybigwig from bw track reading

### DIFF
--- a/docs/api/utils.md
+++ b/docs/api/utils.md
@@ -11,7 +11,7 @@ CREsted provides a few utility function to help with sequence encoding, function
     :toctree: _autosummary
 
     EnhancerOptimizer
-    extract_bigwig_values_per_bp
+    read_bigwig_region
     hot_encoding_to_sequence
     one_hot_encode_sequence
     permute_model

--- a/docs/tutorials/model_training_and_eval.ipynb
+++ b/docs/tutorials/model_training_and_eval.ipynb
@@ -1451,7 +1451,7 @@
    "outputs": [],
    "source": [
     "bigwig = \"/home/VIB.LOCAL/niklas.kempynck/nkemp/mouse/biccn/bigwigs/bws/Sst.bw\"\n",
-    "bw_values, midpoints = crested.utils.extract_bigwig_values_per_bp(bigwig, coordinates)"
+    "bw_values, midpoints = crested.utils.read_bigwig_region(bigwig, coordinates)"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,7 @@ dependencies = [
     "logomaker",
     "pybigtools>=0.2.0",
     "seaborn",
-    "pooch",
-    "pybigwig"
+    "pooch"
 ]
 
 [project.optional-dependencies]

--- a/src/crested/_io.py
+++ b/src/crested/_io.py
@@ -169,7 +169,7 @@ def _extract_tracks_from_bigwig(
                     end,
                     bins = bins,
                     summary = target,
-                    exact = True,
+                    exact = exact,
                     missing = missing,
                     oob = oob,
                     arr = arr

--- a/src/crested/_io.py
+++ b/src/crested/_io.py
@@ -105,16 +105,17 @@ def _extract_values_from_bigwig(
     return values
 
 def _extract_tracks_from_bigwig(
-    bw_file: PathLike, 
-    coordinates: List[tuple[str, int, int]], 
-    bin_size: int | None = None, 
+    bw_file: PathLike,
+    coordinates: list[tuple[str, int, int]],
+    bin_size: int | None = None,
     target: str = 'mean',
     missing: float = 0.0,
     oob: float = 0.0,
     exact: bool = True
 ) -> np.ndarray:
     """
-    Extract per-base or binned pair values of a list of genomic ranges from a bigWig file. 
+    Extract per-base or binned pair values of a list of genomic ranges from a bigWig file.
+
     Expects all coordinate pairs to be the same length.
 
     bigwig_file
@@ -131,7 +132,7 @@ def _extract_tracks_from_bigwig(
         Fill-in value for out-of-bounds regions.
     exact
         Whether to always return the exact values, or to use the built-in zoom levels to interpolate, when binning.
-        Setting exact = False leads to a slight speed advantage, but slight loss in accuracy. 
+        Setting exact = False leads to a slight speed advantage, but slight loss in accuracy.
 
     Returns a numpy array of values from the bigWig file of shape [n_coordinates, n_base_pairs] or [n_coordinates, n_base_pairs//bin_size] if bin_size is set.
     """
@@ -144,7 +145,7 @@ def _extract_tracks_from_bigwig(
         if region_length != prev_region_length:
             raise ValueError(f"All coordinate pairs should be the same length. Coordinate pair {region[0]}:{region[1]}-{region[2]} is not {prev_region_length}bp, but {region_length}bp.")
         prev_region_length = region_length
-    
+
     # Check that length is divisible by bin size
     if bin_size and (region_length % bin_size != 0):
         raise ValueError(f"All region lengths must be divisible by bin_size. Region length {region_length} is not divisible by bin size {bin_size}.")
@@ -159,18 +160,18 @@ def _extract_tracks_from_bigwig(
         for region in coordinates:
             arr = np.empty(binned_length, dtype = 'float64') # pybigtools returns values in float64
             chrom, start, end = region
-            
+
             # Extract values
             results.append(
                 bw.values(
-                    chrom, 
-                    start, 
-                    end, 
-                    bins = bins, 
+                    chrom,
+                    start,
+                    end,
+                    bins = bins,
                     summary = target,
                     exact = True,
-                    missing = missing, 
-                    oob = oob, 
+                    missing = missing,
+                    oob = oob,
                     arr = arr
                 )
             )

--- a/src/crested/_io.py
+++ b/src/crested/_io.py
@@ -104,6 +104,78 @@ def _extract_values_from_bigwig(
 
     return values
 
+def _extract_tracks_from_bigwig(
+    bw_file: PathLike, 
+    coordinates: List[tuple[str, int, int]], 
+    bin_size: int | None = None, 
+    target: str = 'mean',
+    missing: float = 0.0,
+    oob: float = 0.0,
+    exact: bool = True
+) -> np.ndarray:
+    """
+    Extract per-base or binned pair values of a list of genomic ranges from a bigWig file. 
+    Expects all coordinate pairs to be the same length.
+
+    bigwig_file
+        Path to the bigWig file.
+    coordinates
+        A list of tuples looking like (chr, start, end).
+    bin_size
+        If set, the returned values are mean-binned at this resolution.
+    target
+        How to summarize the values per bin, when binning. Can be 'mean', 'min', or 'max'.
+    missing
+        Fill-in value for unreported data in valid regions. Default is 0.
+    oob
+        Fill-in value for out-of-bounds regions.
+    exact
+        Whether to always return the exact values, or to use the built-in zoom levels to interpolate, when binning.
+        Setting exact = False leads to a slight speed advantage, but slight loss in accuracy. 
+
+    Returns a numpy array of values from the bigWig file of shape [n_coordinates, n_base_pairs] or [n_coordinates, n_base_pairs//bin_size] if bin_size is set.
+    """
+    # Wrapper around pybigtools.BBIRead.values().
+
+    # Check that all are same size by iterating and checking with predecessor
+    prev_region_length = coordinates[0][2]-coordinates[0][1]
+    for region in coordinates:
+        region_length = region[2]-region[1]
+        if region_length != prev_region_length:
+            raise ValueError(f"All coordinate pairs should be the same length. Coordinate pair {region[0]}:{region[1]}-{region[2]} is not {prev_region_length}bp, but {region_length}bp.")
+        prev_region_length = region_length
+    
+    # Check that length is divisible by bin size
+    if bin_size and (region_length % bin_size != 0):
+        raise ValueError(f"All region lengths must be divisible by bin_size. Region length {region_length} is not divisible by bin size {bin_size}.")
+
+    # Calculate length (for array creation) and bins (for argument to bw.values)
+    binned_length = region_length // bin_size if bin_size else region_length
+    bins = region_length // bin_size if bin_size else None
+
+    # Open the bigWig file
+    with pybigtools.open(bw_file, "r") as bw:
+        results = []
+        for region in coordinates:
+            arr = np.empty(binned_length, dtype = 'float64') # pybigtools returns values in float64
+            chrom, start, end = region
+            
+            # Extract values
+            results.append(
+                bw.values(
+                    chrom, 
+                    start, 
+                    end, 
+                    bins = bins, 
+                    summary = target,
+                    exact = True,
+                    missing = missing, 
+                    oob = oob, 
+                    arr = arr
+                )
+            )
+
+    return np.vstack(results)
 
 def _read_consensus_regions(
     regions_file: PathLike, chromsizes_file: PathLike | None = None
@@ -485,36 +557,29 @@ def import_bigwigs(
 
     data_matrix = np.vstack(all_results)
 
-    # Create DataFrame for AnnData
-    df = pd.DataFrame(
-        data_matrix,
-        columns=consensus_peaks["region"],
-        index=[
-            os.path.basename(file).rpartition(".")[0].replace(".", "_")
-            for file in bw_files
-        ],
+    # Prepare obs and var for AnnData
+    obs_df = pd.DataFrame(
+        data = {'file_path': bw_files},
+        index = [os.path.basename(file).rpartition(".")[0].replace(".", "_") for file in bw_files]
     )
+    var_df = pd.DataFrame({
+        'region': consensus_peaks["region"],
+        'chr': consensus_peaks["region"].str.split(":").str[0],
+        'start': (consensus_peaks["region"].str.split(":").str[1].str.split("-").str[0]).astype(int),
+        'end': (consensus_peaks["region"].str.split(":").str[1].str.split("-").str[1]).astype(int)
+    }).set_index('region')
 
     # Create AnnData object
-    ann_data = ad.AnnData(df)
-
-    ann_data.obs["file_path"] = bw_files
-    ann_data.var["chr"] = ann_data.var.index.str.split(":").str[0]
-    ann_data.var["start"] = (
-        ann_data.var.index.str.split(":").str[1].str.split("-").str[0]
-    ).astype(int)
-    ann_data.var["end"] = (
-        ann_data.var.index.str.split(":").str[1].str.split("-").str[1]
-    ).astype(int)
+    adata = ad.AnnData(data_matrix, obs = obs_df, var = var_df)
 
     if compress:
-        ann_data.X = csr_matrix(ann_data.X)
+        adata.X = csr_matrix(adata.X)
 
     # Output checks
-    regions_no_values = ann_data.var[ann_data.X.sum(axis=0) == 0]
+    regions_no_values = adata.var[adata.X.sum(axis=0) == 0]
     if not regions_no_values.empty:
         logger.warning(
             f"{len(regions_no_values.index)} consensus regions have no values in any bigWig file",
         )
 
-    return ann_data
+    return adata

--- a/src/crested/pl/hist/_locus_scoring.py
+++ b/src/crested/pl/hist/_locus_scoring.py
@@ -45,7 +45,7 @@ def locus_scoring(
     See Also
     --------
     crested.tl.Crested.score_gene_locus
-    crested.read_bigwig_region
+    crested.utils.read_bigwig_region
 
     Example
     --------

--- a/src/crested/pl/hist/_locus_scoring.py
+++ b/src/crested/pl/hist/_locus_scoring.py
@@ -45,7 +45,7 @@ def locus_scoring(
     See Also
     --------
     crested.tl.Crested.score_gene_locus
-    crested.utils.extract_bigwig_values_per_bp
+    crested.utils.read_bigwig_region
 
     Example
     --------

--- a/src/crested/pl/hist/_locus_scoring.py
+++ b/src/crested/pl/hist/_locus_scoring.py
@@ -45,7 +45,7 @@ def locus_scoring(
     See Also
     --------
     crested.tl.Crested.score_gene_locus
-    crested.utils.read_bigwig_region
+    crested.read_bigwig_region
 
     Example
     --------

--- a/src/crested/utils/__init__.py
+++ b/src/crested/utils/__init__.py
@@ -7,5 +7,5 @@ from ._utils import (
     extract_bigwig_values_per_bp,
     hot_encoding_to_sequence,
     one_hot_encode_sequence,
-    read_bigwig_region
+    read_bigwig_region,
 )

--- a/src/crested/utils/__init__.py
+++ b/src/crested/utils/__init__.py
@@ -7,4 +7,5 @@ from ._utils import (
     extract_bigwig_values_per_bp,
     hot_encoding_to_sequence,
     one_hot_encode_sequence,
+    read_bigwig_region
 )

--- a/src/crested/utils/_utils.py
+++ b/src/crested/utils/_utils.py
@@ -308,17 +308,20 @@ def extract_bigwig_values_per_bp(
     chrom = coordinates[0][0]  # Assuming all coordinates are for the same chromosome
 
     # Extract per-base values
-    bw_values, all_midpoints = read_bigwig_region(bigwig_file, (chrom, min_coord, max_coord), missing = 0.0)
+    bw_values, all_midpoints = read_bigwig_region(
+        bigwig_file, (chrom, min_coord, max_coord), missing=0.0
+    )
 
     return bw_values, all_midpoints
+
 
 def read_bigwig_region(
     bigwig_file: os.PathLike,
     coordinates: tuple[str, int, int],
     bin_size: int | None = None,
-    target: str = 'mean',
+    target: str = "mean",
     missing: float = 0.0,
-    oob: float = 0.0
+    oob: float = 0.0,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
     Extract per-base or binned pair values from a bigWig file for a set of genomic region.
@@ -338,7 +341,6 @@ def read_bigwig_region(
     oob
         Fill-in value for out-of-bounds regions. Default is 0.
 
-
     Returns
     -------
     A tuple of two numpy arrays (values, positions).
@@ -351,24 +353,36 @@ def read_bigwig_region(
     -------
     >>> anndata = crested.read_bigwig_region(
     ...     bw_file="path/to/bigwig",
-    ...     coordinates=('chr1', 0, 32000),
+    ...     coordinates=("chr1", 0, 32000),
     ...     bin_size=32,
-    ...     target="mean"
+    ...     target="mean",
     ... )
     """
     # Check for accidental passing of lists of coordinates or wrong orders
-    if not (isinstance(coordinates[0], str) and isinstance(coordinates[1], int) and isinstance(coordinates[2], int)):
-        raise ValueError("Your coordinates must be a single tuple of types (str, int, int).")
+    if not (
+        isinstance(coordinates[0], str)
+        and isinstance(coordinates[1], int)
+        and isinstance(coordinates[2], int)
+    ):
+        raise ValueError(
+            "Your coordinates must be a single tuple of types (str, int, int)."
+        )
     if not (coordinates[1] < coordinates[2]):
-        raise ValueError(f"End coordinate {coordinates[2]} should be bigger than start coordinate {coordinates[1]}")
+        raise ValueError(
+            f"End coordinate {coordinates[2]} should be bigger than start coordinate {coordinates[1]}"
+        )
 
     # Get locations of the values given the binning
     if bin_size:
-        positions = np.arange(start = coordinates[1]+bin_size/2, stop = coordinates[2], step = bin_size)
+        positions = np.arange(
+            start=coordinates[1] + bin_size / 2, stop=coordinates[2], step=bin_size
+        )
     else:
         positions = np.arange(coordinates[1], coordinates[2])
 
     # Get values
-    values =  _extract_tracks_from_bigwig(bigwig_file, [coordinates], bin_size, target, missing, oob).squeeze()
+    values = _extract_tracks_from_bigwig(
+        bigwig_file, [coordinates], bin_size, target, missing, oob
+    ).squeeze()
 
     return values, positions

--- a/src/crested/utils/_utils.py
+++ b/src/crested/utils/_utils.py
@@ -319,7 +319,7 @@ def read_bigwig_region(
     target: str = 'mean',
     missing: float = 0.0,
     oob: float = 0.0
-) -> np.ndarray:
+) -> tuple[np.ndarray, np.ndarray]:
     """
     Extract per-base or binned pair values from a bigWig file for a set of genomic region.
 

--- a/src/crested/utils/_utils.py
+++ b/src/crested/utils/_utils.py
@@ -6,7 +6,8 @@ from typing import Any, Callable
 import numpy as np
 import pandas as pd
 from loguru import logger
-from .._io import _extract_tracks_from_bigwig
+
+from crested._io import _extract_tracks_from_bigwig
 
 
 def get_hot_encoding_table(
@@ -294,7 +295,7 @@ def extract_bigwig_values_per_bp(
         A list of all base pair positions covered in the specified coordinates.
     """
     logger.warning(
-        f"extract_bigwig_values_per_bp() is deprecated. Please use crested.utils.read_bigwig_region(bw_file, (chr, start, end)) instead."
+        "extract_bigwig_values_per_bp() is deprecated. Please use crested.utils.read_bigwig_region(bw_file, (chr, start, end)) instead."
     )
     # Calculate the full range of coordinates
     min_coord = min([int(start) for _, start, _ in coordinates])
@@ -312,15 +313,15 @@ def extract_bigwig_values_per_bp(
     return bw_values, all_midpoints
 
 def read_bigwig_region(
-    bigwig_file: PathLike, 
-    coordinates: tuple[str, int, int], 
-    bin_size: int | None = None, 
+    bigwig_file: os.PathLike,
+    coordinates: tuple[str, int, int],
+    bin_size: int | None = None,
     target: str = 'mean',
     missing: float = 0.0,
     oob: float = 0.0
 ) -> np.ndarray:
     """
-    Helper function to extract per-base or binned pair values from a bigWig file for a set of genomic region.
+    Extract per-base or binned pair values from a bigWig file for a set of genomic region.
 
     Parameters
     ----------
@@ -331,7 +332,7 @@ def read_bigwig_region(
     bin_size
         If set, the returned values are mean-binned at this resolution.
     target
-        How to summarize the values per bin, when binning. Can be 'mean', 'min', or 'max'.    
+        How to summarize the values per bin, when binning. Can be 'mean', 'min', or 'max'.
     missing
         Fill-in value for unreported data in valid regions. Default is 0.
     oob
@@ -357,7 +358,7 @@ def read_bigwig_region(
     """
     # Check for accidental passing of lists of coordinates or wrong orders
     if not (isinstance(coordinates[0], str) and isinstance(coordinates[1], int) and isinstance(coordinates[2], int)):
-        raise ValueError(f"Your coordinates must be a single tuple of types (str, int, int).")
+        raise ValueError("Your coordinates must be a single tuple of types (str, int, int).")
     if not (coordinates[1] < coordinates[2]):
         raise ValueError(f"End coordinate {coordinates[2]} should be bigger than start coordinate {coordinates[1]}")
 

--- a/src/crested/utils/_utils.py
+++ b/src/crested/utils/_utils.py
@@ -343,8 +343,7 @@ def read_bigwig_region(
 
     Returns
     -------
-    A tuple of two numpy arrays (values, positions).
-    values:
+    values
         numpy array with the values from the bigwig for the requested coordinates. Shape: [n_bp], or [n_bp//bin_size] if bin_size is specified.
     positions
         numpy array with genomic positions as integers of the values in values. Shape: [n_bp], or [n_bp//bin_size] if bin_size is specified.

--- a/src/crested/utils/_utils.py
+++ b/src/crested/utils/_utils.py
@@ -5,7 +5,8 @@ from typing import Any, Callable
 
 import numpy as np
 import pandas as pd
-import pyBigWig
+from loguru import logger
+from .._io import _extract_tracks_from_bigwig
 
 
 def get_hot_encoding_table(
@@ -292,6 +293,9 @@ def extract_bigwig_values_per_bp(
     all_midpoints
         A list of all base pair positions covered in the specified coordinates.
     """
+    logger.warning(
+        f"extract_bigwig_values_per_bp() is deprecated. Please use crested.utils.read_bigwig_region(bw_file, (chr, start, end)) instead."
+    )
     # Calculate the full range of coordinates
     min_coord = min([int(start) for _, start, _ in coordinates])
     max_coord = max([int(end) for _, _, end in coordinates])
@@ -299,21 +303,71 @@ def extract_bigwig_values_per_bp(
     # Initialize the list to store values
     bw_values = []
 
-    # Open the bigWig file
-    bw = pyBigWig.open(bigwig_file)
-
-    # Iterate over each chromosome (all coordinates should be for the same chromosome)
+    # Get chromosome
     chrom = coordinates[0][0]  # Assuming all coordinates are for the same chromosome
 
     # Extract per-base values
-    bw_values = bw.values(chrom, min_coord, max_coord)
-
-    # Replace NaN with 0
-    bw_values = np.nan_to_num(bw_values, nan=0)
-
-    # Generate the list of all base pair positions
-    all_midpoints = list(range(min_coord, max_coord))
-
-    bw.close()
+    bw_values, all_midpoints = read_bigwig_region(bigwig_file, (chrom, min_coord, max_coord), missing = 0.0)
 
     return bw_values, all_midpoints
+
+def read_bigwig_region(
+    bigwig_file: PathLike, 
+    coordinates: tuple[str, int, int], 
+    bin_size: int | None = None, 
+    target: str = 'mean',
+    missing: float = 0.0,
+    oob: float = 0.0
+) -> np.ndarray:
+    """
+    Helper function to extract per-base or binned pair values from a bigWig file for a set of genomic region.
+
+    Parameters
+    ----------
+    bigwig_file
+        Path to the bigWig file.
+    coordinates
+        A tuple looking like (chr, start, end).
+    bin_size
+        If set, the returned values are mean-binned at this resolution.
+    target
+        How to summarize the values per bin, when binning. Can be 'mean', 'min', or 'max'.    
+    missing
+        Fill-in value for unreported data in valid regions. Default is 0.
+    oob
+        Fill-in value for out-of-bounds regions. Default is 0.
+
+
+    Returns
+    -------
+    A tuple of two numpy arrays (values, positions).
+    values:
+        numpy array with the values from the bigwig for the requested coordinates. Shape: [n_bp], or [n_bp//bin_size] if bin_size is specified.
+    positions
+        numpy array with genomic positions as integers of the values in values. Shape: [n_bp], or [n_bp//bin_size] if bin_size is specified.
+
+    Example
+    -------
+    >>> anndata = crested.read_bigwig_region(
+    ...     bw_file="path/to/bigwig",
+    ...     coordinates=('chr1', 0, 32000),
+    ...     bin_size=32,
+    ...     target="mean"
+    ... )
+    """
+    # Check for accidental passing of lists of coordinates or wrong orders
+    if not (isinstance(coordinates[0], str) and isinstance(coordinates[1], int) and isinstance(coordinates[2], int)):
+        raise ValueError(f"Your coordinates must be a single tuple of types (str, int, int).")
+    if not (coordinates[1] < coordinates[2]):
+        raise ValueError(f"End coordinate {coordinates[2]} should be bigger than start coordinate {coordinates[1]}")
+
+    # Get locations of the values given the binning
+    if bin_size:
+        positions = np.arange(start = coordinates[1]+bin_size/2, stop = coordinates[2], step = bin_size)
+    else:
+        positions = np.arange(coordinates[1], coordinates[2])
+
+    # Get values
+    values =  _extract_tracks_from_bigwig(bigwig_file, [coordinates], bin_size, target, missing, oob).squeeze()
+
+    return values, positions


### PR DESCRIPTION
Updates the bigwig track reading (for visualisation, i.e. for genome scanning comparisons, and for models later on).

Three changes + one bonus:
### 1. New backend bigwig track reading function
I added a function in `_io`, `_extract_tracks_from_bigwig()` which wraps around pybigtools' `values()`.
It supports binning by default, and is intended to be a robust backend function for reading in bigwig tracks. It could be faster by requesting some changes in pybigtools, see below. 

### 2. Removal of pybigwig from the old function 
The old function (`extract_bigwig_values_per_bp`) is still there, with the backend changed to the new function. 
However, the way it works is very counterintuitive, as it asks for a list of regions but then returns the values for everything between the min and max of those regions, and completely ignores different potential chromosomes of the different regions. 

Long story short, I've updated it but added a deprecation notice, as I recommend using the new function `read_bigwig_region()`. 

### 3. New track reading function
Added `read_bigwig_region()`. This function just asks for a single set of coordinates and returns the values in between, also supporting binning and other nice features. Should be more straightforward.

### Bonus change: slight optimalisation in `import_bigwigs()`
This function made an AnnData by creating a dataframe out of a numpy array, which anndata converts back to a numpy array immediately. It's more logical to keep the matrix as an array and just bundle the obs and var with it during creation of the anndata object. I've also checked that this returns equivalent AnnData objects. Note that `import_beds()` does something similar but by constructing the entire thing in a DataFrame. This also doesn't really make sense, but I don't feel like wrapping my head around the code and optimising it atm.


### Todo:
There's a few things that could still be checked:
- I checked whether the old and new function return identical outputs on a random bigwig region, but I'm not sure whether that region had NaN values in the bigWig. Those should be accounted for by the function, but it's untested.
- There's the `exact` parameter, which allows you to speed up getting values for bins by using the zoom level values in bigwigs. I think that's not really relevant for the levels at which we're looking, though. I've kept it at `exact=True` to be sure, but if the function ends up being a bottleneck checking the accuracy-speed tradeoff here can be worth it.


There's also a few possible improvements for `_extract_tracks_from_bigwig()` which require changes in pybigtools itself:
- It sadly doesn't work as an iterator over regions since that's not exposed from within rust.
- Similarly, if we were to extract lots of regions as in a bed file (which is where I want to go), we'd need to read that bed file into python and pass the list of regions, rather than passing the bed file to rust immediately.
- It currently supports 'min', 'mean', and 'max', which doesn't line up perfectly with the 'target' arguments of `average_over_bed()`. I think? that it should take mean in a similar way as we take mean (i.e. set NaNs to 0, 'mean0' in `average_over_bed` as long as you have `missing=0.0` (which we set as default).

