### PR TITLE
Add strand support to AnnDataset and fix deterministic_shift

### DIFF
--- a/src/crested/tl/_crested.py
+++ b/src/crested/tl/_crested.py
@@ -1392,10 +1392,7 @@ class Crested:
             enhancer_optimizer = EnhancerOptimizer(optimize_func=_weighted_difference)
 
         # get input sequence length of the model
-        seq_len = (
-            self.anndatamodule.adata.var.iloc[0]["end"]
-            - self.anndatamodule.adata.var.iloc[0]["start"]
-        )
+        seq_len = self.model.input_shape[1]
 
         # determine the flanks without changes
         if no_mutation_flanks is not None and target_len is not None:
@@ -1590,10 +1587,7 @@ class Crested:
             enhancer_optimizer = EnhancerOptimizer(optimize_func=_weighted_difference)
 
         # get input sequence length of the model
-        seq_len = (
-            self.anndatamodule.adata.var.iloc[0]["end"]
-            - self.anndatamodule.adata.var.iloc[0]["start"]
-        )
+        seq_len = self.model.input_shape[1]
 
         # determine the flanks without changes
         if no_mutation_flanks is not None and target_len is not None:

--- a/src/crested/tl/_crested.py
+++ b/src/crested/tl/_crested.py
@@ -570,7 +570,7 @@ class Crested:
         """
         Extract embeddings from a specified layer in the model for all regions in the dataset.
 
-        If anndata is provided, it will add the embeddings to anndata.obsm[layer_name].
+        If anndata is provided, it will add the embeddings to anndata.varm[layer_name].
 
         Parameters
         ----------
@@ -581,7 +581,7 @@ class Crested:
 
         Returns
         -------
-        Embeddings of shape (N, D), where D is the size of the embedding layer.
+        Embeddings of shape (N, D), where N is the number of regions in the dataset and D is the size of the embedding layer.
         """
         if layer_name not in [layer.name for layer in self.model.layers]:
             raise ValueError(f"Layer '{layer_name}' not found in model.")
@@ -597,7 +597,7 @@ class Crested:
         embeddings = embedding_model.predict(predict_loader.data, steps=n_predict_steps)
 
         if anndata is not None:
-            anndata.obsm[layer_name] = embeddings
+            anndata.varm[layer_name] = embeddings
         return embeddings
 
     def predict(

--- a/src/crested/tl/_crested.py
+++ b/src/crested/tl/_crested.py
@@ -652,7 +652,7 @@ class Crested:
         Parameters
         ----------
         region_idx
-            List of regions for which to make predictions in the format "chr:start-end".
+            List of regions for which to make predictions in the format of your original data, either "chr:start-end" or "chr:start-end:strand".
 
         Returns
         -------
@@ -959,7 +959,7 @@ class Crested:
         Parameters
         ----------
         region_idx
-            Region(s) for which to calculate the contribution scores in the format "chr:start-end".
+            Region(s) for which to calculate the contribution scores in the format "chr:start-end" or "chr:start-end:strand".
         class_names
             List of class names to calculate the contribution scores for (should match anndata.obs_names)
             If the list is empty, the contribution scores for the 'combined' class will be calculated.

--- a/src/crested/tl/data/_anndatamodule.py
+++ b/src/crested/tl/data/_anndatamodule.py
@@ -49,6 +49,9 @@ class AnnDataModule:
         If True, the sequences will be randomly reverse complemented during training. Default is False.
     max_stochastic_shift
         Maximum stochastic shift (n base pairs) to apply randomly to each sequence during training. Default is 0.
+    deterministic_shift
+        If true, each region will be shifted twice with stride 50bp to each side. Default is False.
+        This is our legacy shifting, we recommend using max_stochastic_shift instead.
     shuffle
         If True, the data will be shuffled at the end of each epoch during training. Default is True.
     batch_size
@@ -64,18 +67,11 @@ class AnnDataModule:
         always_reverse_complement=True,
         random_reverse_complement: bool = False,
         max_stochastic_shift: int = 0,
+        deterministic_shift: bool = False,
         shuffle: bool = True,
         batch_size: int = 256,
-        deterministic_shift = None
     ):
         """Initialize the DataModule with the provided dataset and options."""
-        if deterministic_shift is not None:
-            determ_shift_warning = "Argument `deterministic_shift` is deprecated and is no longer functional. Use max_stochastic_shift instead."
-            if max_stochastic_shift == 0:
-                determ_shift_warning +=  " Setting max_stochastic_shift to 3."
-                max_stochastic_shift = 3
-            logger.warning(determ_shift_warning)
-
         self.adata = adata
         self.genome_file = genome_file
         self.chromsizes_file = chromsizes_file
@@ -83,6 +79,7 @@ class AnnDataModule:
         self.in_memory = in_memory
         self.random_reverse_complement = random_reverse_complement
         self.max_stochastic_shift = max_stochastic_shift
+        self.deterministic_shift = deterministic_shift
         self.shuffle = shuffle
         self.batch_size = batch_size
 
@@ -133,6 +130,7 @@ class AnnDataModule:
                 always_reverse_complement=self.always_reverse_complement,
                 random_reverse_complement=self.random_reverse_complement,
                 max_stochastic_shift=self.max_stochastic_shift,
+                deterministic_shift=self.deterministic_shift,
             )
             self.val_dataset = AnnDataset(
                 self.adata,

--- a/src/crested/tl/data/_anndatamodule.py
+++ b/src/crested/tl/data/_anndatamodule.py
@@ -49,9 +49,6 @@ class AnnDataModule:
         If True, the sequences will be randomly reverse complemented during training. Default is False.
     max_stochastic_shift
         Maximum stochastic shift (n base pairs) to apply randomly to each sequence during training. Default is 0.
-    deterministic_shift
-        If true, each region will be shifted twice with stride 50bp to each side. Default is False.
-        This is our legacy shifting, we recommend using max_stochastic_shift instead.
     shuffle
         If True, the data will be shuffled at the end of each epoch during training. Default is True.
     batch_size
@@ -67,11 +64,18 @@ class AnnDataModule:
         always_reverse_complement=True,
         random_reverse_complement: bool = False,
         max_stochastic_shift: int = 0,
-        deterministic_shift: bool = False,
         shuffle: bool = True,
         batch_size: int = 256,
+        deterministic_shift = None
     ):
         """Initialize the DataModule with the provided dataset and options."""
+        if deterministic_shift is not None:
+            determ_shift_warning = "Argument `deterministic_shift` is deprecated and is no longer functional. Use max_stochastic_shift instead."
+            if max_stochastic_shift == 0:
+                determ_shift_warning +=  " Setting max_stochastic_shift to 3."
+                max_stochastic_shift = 3
+            logger.warning(determ_shift_warning)
+
         self.adata = adata
         self.genome_file = genome_file
         self.chromsizes_file = chromsizes_file
@@ -79,7 +83,6 @@ class AnnDataModule:
         self.in_memory = in_memory
         self.random_reverse_complement = random_reverse_complement
         self.max_stochastic_shift = max_stochastic_shift
-        self.deterministic_shift = deterministic_shift
         self.shuffle = shuffle
         self.batch_size = batch_size
 
@@ -130,7 +133,6 @@ class AnnDataModule:
                 always_reverse_complement=self.always_reverse_complement,
                 random_reverse_complement=self.random_reverse_complement,
                 max_stochastic_shift=self.max_stochastic_shift,
-                deterministic_shift=self.deterministic_shift,
             )
             self.val_dataset = AnnDataset(
                 self.adata,

--- a/src/crested/tl/data/_dataset.py
+++ b/src/crested/tl/data/_dataset.py
@@ -243,6 +243,23 @@ class IndexManager:
                     augmented_indices_map[_flip_region_strand(stranded_region)] = region
         return augmented_indices, augmented_indices_map
 
+    def _deterministic_shift_region(
+        self, region: str, stride: int = 50, n_shifts: int = 2
+    ) -> list[str]:
+        """
+        Shift each region by a deterministic stride to each side. Will increase the number of regions by n_shifts times two.
+
+        This is a legacy function, it's recommended to use stochastic shifting instead.
+        """
+        new_regions = []
+        chrom, start_end, strand = region.split(":")
+        start, end = map(int, start_end.split("-"))
+        for i in range(-n_shifts, n_shifts + 1):
+            new_start = start + i * stride
+            new_end = end + i * stride
+            new_regions.append(f"{chrom}:{new_start}-{new_end}:{strand}")
+        return new_regions
+
 
 if os.environ["KERAS_BACKEND"] == "pytorch":
     import torch

--- a/src/crested/tl/data/_dataset.py
+++ b/src/crested/tl/data/_dataset.py
@@ -220,20 +220,16 @@ class IndexManager:
         List of indices in format "chr:start-end" or "chr:start-end:strand".
     always_reverse_complement
         If True, all sequences will be augmented with their reverse complement.
-    deterministic_shift
-        If True, each region will be shifted twice with stride 50bp to each side.
     """
 
     def __init__(
         self,
         indices: list[str],
         always_reverse_complement: bool,
-        deterministic_shift: bool = False,
     ):
         """Initialize the IndexManager with the provided indices."""
         self.indices = indices
         self.always_reverse_complement = always_reverse_complement
-        self.deterministic_shift = deterministic_shift
         self.augmented_indices, self.augmented_indices_map = self._augment_indices(
             indices
         )
@@ -251,21 +247,11 @@ class IndexManager:
                 stranded_region = f"{region}:+"
             else:
                 stranded_region = region
-
-            if self.deterministic_shift:
-                shifted_regions = self._deterministic_shift_region(stranded_region)
-                for shifted_region in shifted_regions:
-                    augmented_indices.append(shifted_region)
-                    augmented_indices_map[shifted_region] = region
-                    if self.always_reverse_complement:
-                        augmented_indices.append(_flip_region_strand(shifted_region))
-                        augmented_indices_map[_flip_region_strand(shifted_region)] = region
-            else:
-                augmented_indices.append(stranded_region)
-                augmented_indices_map[stranded_region] = region
-                if self.always_reverse_complement:
-                    augmented_indices.append(_flip_region_strand(stranded_region))
-                    augmented_indices_map[_flip_region_strand(stranded_region)] = region
+            augmented_indices.append(stranded_region)
+            augmented_indices_map[stranded_region] = region
+            if self.always_reverse_complement:
+                augmented_indices.append(_flip_region_strand(stranded_region))
+                augmented_indices_map[_flip_region_strand(stranded_region)] = region
         return augmented_indices, augmented_indices_map
 
     def _deterministic_shift_region(
@@ -318,9 +304,6 @@ class AnnDataset(BaseClass):
         If True, all sequences will be augmented with their reverse complement during training.
     max_stochastic_shift
         Maximum stochastic shift (n base pairs) to apply randomly to each sequence during training.
-    deterministic_shift
-        If true, each region will be shifted twice with stride 50bp to each side.
-        This is our legacy shifting, we recommend using max_stochastic_shift instead.
     """
 
     def __init__(
@@ -333,7 +316,6 @@ class AnnDataset(BaseClass):
         random_reverse_complement: bool = False,
         always_reverse_complement: bool = False,
         max_stochastic_shift: int = 0,
-        deterministic_shift: bool = False,
     ):
         """Initialize the dataset with the provided AnnData object and options."""
         self.anndata = self._split_anndata(anndata, split)
@@ -367,8 +349,7 @@ class AnnDataset(BaseClass):
         )
         self.index_manager = IndexManager(
             self.indices,
-            always_reverse_complement=always_reverse_complement,
-            deterministic_shift=deterministic_shift,
+            always_reverse_complement=always_reverse_complement
         )
         self.seq_len = len(self.sequence_loader.get_sequence(self.indices[0]))
 

--- a/src/crested/tl/data/_dataset.py
+++ b/src/crested/tl/data/_dataset.py
@@ -254,23 +254,6 @@ class IndexManager:
                 augmented_indices_map[_flip_region_strand(stranded_region)] = region
         return augmented_indices, augmented_indices_map
 
-    def _deterministic_shift_region(
-        self, region: str, stride: int = 50, n_shifts: int = 2
-    ) -> list[str]:
-        """
-        Shift each region by a deterministic stride to each side. Will increase the number of regions by n_shifts times two.
-
-        This is a legacy function, it's recommended to use stochastic shifting instead.
-        """
-        new_regions = []
-        chrom, start_end, strand = region.split(":")
-        start, end = map(int, start_end.split("-"))
-        for i in range(-n_shifts, n_shifts + 1):
-            new_start = start + i * stride
-            new_end = end + i * stride
-            new_regions.append(f"{chrom}:{new_start}-{new_end}:{strand}")
-        return new_regions
-
 
 if os.environ["KERAS_BACKEND"] == "pytorch":
     import torch

--- a/src/crested/tl/data/_dataset.py
+++ b/src/crested/tl/data/_dataset.py
@@ -108,7 +108,6 @@ class SequenceLoader:
     def _load_sequences_into_memory(self, regions: list[str]):
         """Load all sequences into memory (dict)."""
         logger.info("Loading sequences into memory...")
-        strand_reverser = {'+': '-', '-': '+'}
         # Check region formatting
         stranded = _check_strandedness(regions[0])
 
@@ -133,11 +132,11 @@ class SequenceLoader:
 
                 # Add region to self.sequences
                 extended_sequence = self._get_extended_sequence(chrom, start, end, strand)
-                self.sequences[f"{chrom}:{start}-{end}:{strand}"] = extended_sequence
+                self.sequences[region] = extended_sequence
 
                 # Add reverse-complemented region to self.sequences if always_reverse_complement
                 if self.always_reverse_complement:
-                    self.sequences[f"{chrom}:{start}-{end}:{strand_reverser[strand]}"] = self._reverse_complement(
+                    self.sequences[_flip_region_strand(region)] = self._reverse_complement(
                         extended_sequence
                     )
 

--- a/src/crested/tl/data/_dataset.py
+++ b/src/crested/tl/data/_dataset.py
@@ -409,9 +409,9 @@ class AnnDataset(BaseClass):
             shift = np.random.randint(
                 -self.max_stochastic_shift, self.max_stochastic_shift + 1
             )
-            x = self.sequence_loader.get_sequence(original_index, shift = shift)
+            x = self.sequence_loader.get_sequence(augmented_index, shift = shift)
         else:
-            x = self.sequence_loader.get_sequence(original_index)
+            x = self.sequence_loader.get_sequence(augmented_index)
 
         # random reverse complement (always_reverse_complement is done in the sequence loader)
         if self.random_reverse_complement and np.random.rand() < 0.5:

--- a/src/crested/tl/data/_dataset.py
+++ b/src/crested/tl/data/_dataset.py
@@ -37,7 +37,9 @@ def _check_strandedness(region: str) -> bool:
     elif re.fullmatch(r".+:\d+-\d+", region):
         return False
     else:
-        raise ValueError(f"Region {region} was not recognised as a valid coordinate set (chr:start-end or chr:start-end:strand).")
+        raise ValueError(
+            f"Region {region} was not recognised as a valid coordinate set (chr:start-end or chr:start-end:strand)."
+            "If provided, strand must be + or -.")
 
 
 class SequenceLoader:

--- a/src/crested/tl/data/_dataset.py
+++ b/src/crested/tl/data/_dataset.py
@@ -409,7 +409,7 @@ class AnnDataset(BaseClass):
             shift = np.random.randint(
                 -self.max_stochastic_shift, self.max_stochastic_shift + 1
             )
-            x = self.sequence_loader.get_sequence(original_index, shift)
+            x = self.sequence_loader.get_sequence(original_index, shift = shift)
         else:
             x = self.sequence_loader.get_sequence(original_index)
 

--- a/src/crested/tl/data/_dataset.py
+++ b/src/crested/tl/data/_dataset.py
@@ -348,6 +348,11 @@ class AnnDataset(BaseClass):
 
         # Check region formatting
         stranded = _check_strandedness(self.indices[0])
+        if stranded and (always_reverse_complement or random_reverse_complement):
+            logger.info(
+                    "Setting always_reverse_complement=True or random_reverse_complement=True with stranded data.",
+                    "This means both strands are used when training and the strand information is effectively disregarded."
+                )
 
         self.sequence_loader = SequenceLoader(
             genome_file,


### PR DESCRIPTION
Adds support for stranded datasets (so anndatas with indices (chr:start-end:strand), like gene data) while preserving support for non-stranded datasets (like ATAC data). I checked whether loading data works with stranded and unstranded data in-memory and not in-memory and with/without always_reverse_complement.

To do still:
- [x] Check whether the downstream functions (crested object functions, like preds and explanations) still work. I looked at the code and nothing should need changes, but I haven't actually tested them yet - I can do that or someone else can quickly rerun an analysis notebook with this branch to see if everything works.

Also has two small bugfixes:
- `get_embeddings()` was trying to save per-gene embeddings in `anndata.obsm` (which is for per-pseudobulk observations). Changed this to `.varm` and tested that it works.
- the `Crested.enhancer_design_*` functions were deriving start and end from the var columns, but that's not robust: the the anndataset object always reads the full region string to get start and end, and indeed in my code (and I believe also if you use the expand region width function?) the regions and the start/end might be out of sync. Anyway, this was to get the model input size, so we can just use `self.model.input_shape` and not have to worry about it.

Edit: and a bigger bugfix: it fixes 'deterministic_shift', since it was broken before and didn't actually shift the sequences.