### PR TITLE
only upload docs on release

### DIFF
--- a/.github/workflows/docs_upload.yaml
+++ b/.github/workflows/docs_upload.yaml
@@ -1,10 +1,8 @@
-name: Check Sphinx Docs
+name: Upload Sphinx Docs
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  release:
+    types: [published]
 
 jobs:
   docs:
@@ -35,6 +33,13 @@ jobs:
           make clean
           # Build the docs and capture output, treat warnings as errors (-W)
           sphinx-build -b html -W . _build/html 2>&1 | tee sphinx-output.log
+
+      - name: Upload Documentation Artifacts (HTML Pages)
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: sphinx-docs
+          path: docs/_build/html
 
       - name: Upload Log if Build Failed
         if: failure()

--- a/src/crested/tl/_crested.py
+++ b/src/crested/tl/_crested.py
@@ -1341,7 +1341,6 @@ class Crested:
         target: int | np.ndarray | None = None,
         insertions_per_pattern: dict | None = None,
         return_intermediate: bool = False,
-        class_penalty_weights: np.ndarray | None = None,
         no_mutation_flanks: tuple | None = None,
         target_len: int | None = None,
         preserve_inserted_motifs: bool = True,
@@ -1369,9 +1368,6 @@ class Crested:
         return_intermediate
             If True, returns a dictionary with predictions and changes made in intermediate steps for selected
             sequences
-        class_penalty_weights
-            Array with a value per class, determining the penalty weight for that class to be used in scoring
-            function for sequence selection.
         no_mutation_flanks
             A tuple of integers which determine the regions in each flank to not do implementations.
         target_len


### PR DESCRIPTION
Don't always upload docs when pushing to main, but only on a new release.

Tried adding a 'version picker' box, but this is not supported with our default theme.