### PR TITLE
move tangermeme dep out of optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ pip install torch
 pip install crested
 ```
 
-3. If you plan on doing motif analysis using the tf-modisco (lite) and tangermeme's tomtom functionality inside CREsted, you will need to run the following additional install:
+3. If you plan on doing motif analysis using the tf-modisco (lite) inside CREsted, you will need to run the following additional install:
 
 ```bash
-pip install crested[tfmodisco]
+pip install "modisco-lite>=2.2.1"
 ```
 
-This requires a cmake installation on your system. If you don't have it, you can install it with:
+Modiscolite may require a cmake installation on your system. If you don't have it, you can install it with:
 
 ```bash
 pip install cmake

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,11 +36,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-tfmodisco = [
-    "modisco-lite>=2.2.1",
-    "tangermeme"
-]
-
 dev = [
     "pre-commit",
     "twine>=4.0.2",

--- a/src/crested/tl/modisco/_modisco_utils.py
+++ b/src/crested/tl/modisco/_modisco_utils.py
@@ -407,7 +407,10 @@ def match_score_patterns(a: dict, b: dict) -> float:
     try:
         from tangermeme.tools import tomtom as tangermeme_tomtom
     except ImportError as e:
-        raise ImportError("Please install tangermeme to use this function.") from e
+        raise ImportError(
+            "Please install tangermeme to use this function with 'pip install tangermeme'. \
+            Warning: tangermeme also installs torch and may cause issues with a tensorflow environment."
+        ) from e
     try:
         score = tangermeme_tomtom.tomtom(Qs=[ic_a.T], Ts=[ic_b.T])[0, 0][0]
     except Exception as e:  # noqa: BLE001


### PR DESCRIPTION
tangermeme installs torch and causes issues with a tensorflow backend environment.
Now crested raises a warning to pip install tangermeme only when trying to use the function it requires.
