### PR TITLE
continue training from existing checkpoint

### DIFF
--- a/docs/tutorials/model_training_and_eval.ipynb
+++ b/docs/tutorials/model_training_and_eval.ipynb
@@ -93,7 +93,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bigwigs_folder = \"/home/VIB.LOCAL/niklas.kempynck/nkemp/mouse/biccn/bigwigs/fragments_bws/\"\n",
+    "bigwigs_folder = (\n",
+    "    \"/home/VIB.LOCAL/niklas.kempynck/nkemp/mouse/biccn/bigwigs/fragments_bws/\"\n",
+    ")\n",
     "regions_file = (\n",
     "    \"/home/VIB.LOCAL/niklas.kempynck/nkemp/mouse/biccn/consensus_peaks_inputs.bed\"\n",
     ")\n",
@@ -554,7 +556,9 @@
    ],
    "source": [
     "%matplotlib inline\n",
-    "crested.pl.bar.normalization_weights(adata, title=\"Normalization Weights per Cell Type\", x_label_rotation=90)"
+    "crested.pl.bar.normalization_weights(\n",
+    "    adata, title=\"Normalization Weights per Cell Type\", x_label_rotation=90\n",
+    ")"
    ]
   },
   {
@@ -767,7 +771,11 @@
     "By default: \n",
     "1. The model will continue training until the validation loss stops decreasing for 10 epochs with a maximum of 100 epochs.  \n",
     "2. Every best model is saved based on the validation loss.\n",
-    "3. The learning rate reduces by a factor of 0.25 if the validation loss stops decreasing for 5 epochs."
+    "3. The learning rate reduces by a factor of 0.25 if the validation loss stops decreasing for 5 epochs.\n",
+    "\n",
+    "```{note}\n",
+    "If you specify the same project_name and run_name as a previous run, then CREsted will assume that you want to continue training and will load the last available model checkpoint from the {project_name}/{run_name} folder and continue from that epoch.\n",
+    "```"
    ]
   },
   {
@@ -2140,8 +2148,8 @@
     "import matplotlib\n",
     "\n",
     "# Set the font type to ensure text is saved as whole words\n",
-    "matplotlib.rcParams['pdf.fonttype'] = 42  # Use TrueType fonts instead of Type 3 fonts\n",
-    "matplotlib.rcParams['ps.fonttype'] = 42   # For PostScript as well, if needed\n",
+    "matplotlib.rcParams[\"pdf.fonttype\"] = 42  # Use TrueType fonts instead of Type 3 fonts\n",
+    "matplotlib.rcParams[\"ps.fonttype\"] = 42  # For PostScript as well, if needed\n",
     "\n",
     "classn = \"L2_3IT\"\n",
     "crested.pl.scatter.class_density(\n",
@@ -2224,7 +2232,13 @@
    ],
    "source": [
     "crested.pl.heatmap.correlations_self(\n",
-    "    adata, title=\"Self Correlation Heatmap\", x_label_rotation=90, width=5, height=5, vmax=1, vmin=-0.15\n",
+    "    adata,\n",
+    "    title=\"Self Correlation Heatmap\",\n",
+    "    x_label_rotation=90,\n",
+    "    width=5,\n",
+    "    height=5,\n",
+    "    vmax=1,\n",
+    "    vmin=-0.15,\n",
     ")"
    ]
   },

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -38,6 +38,11 @@ def test_peak_regression():
     print(adata.var)
     print(adata.var_names)
 
+    if os.path.exists("tests/data/test_pipeline"):
+        import shutil
+
+        shutil.rmtree("tests/data/test_pipeline")
+
     datamodule = crested.tl.data.AnnDataModule(
         adata,
         genome_file="tests/data/genomes/hg38/hg38.fa",
@@ -102,4 +107,17 @@ def test_peak_regression():
     )
     crested.pl.patterns.enhancer_design_steps_contribution_scores(
         intermediate, scores, seqs
+    )
+    # test continue training
+    trainer_2 = crested.tl.Crested(
+        data=datamodule,
+        model=model_architecture,
+        config=config,
+        project_name="tests/data/test_pipeline",
+        run_name="test_peak_regression",
+        logger=None,
+    )
+    trainer_2.fit(epochs=2)
+    assert os.path.exists(
+        "tests/data/test_pipeline/test_peak_regression/checkpoints/02.keras"
     )


### PR DESCRIPTION
- Will continue training from last found checkpoint if the same project and run_name are initialized in the Crested(..) class
This changes the previous behaviour of overwriting that folder if it already existed.
- Fixes an issue that would always recompile when doing a fit() so optimizer states weren't continued.