### PR TITLE
fix incorrect return None in Crested.test(...)

### DIFF
--- a/src/crested/tl/_crested.py
+++ b/src/crested/tl/_crested.py
@@ -578,9 +578,9 @@ class Crested:
         # Log the evaluation results
         for metric_name, metric_value in evaluation_metrics.items():
             logger.info(f"Test {metric_name}: {metric_value:.4f}")
-            return None
         if return_metrics:
             return evaluation_metrics
+        return None
 
     def get_embeddings(
         self,

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -79,7 +79,9 @@ def test_peak_regression():
         "tests/data/test_pipeline/test_peak_regression/checkpoints/01.keras",
         compile=True,
     )
-    trainer.test()
+
+    test_metrics = trainer.test(return_metrics=True)
+    assert isinstance(test_metrics, dict)
     trainer.predict(adata, model_name="01")
 
     trainer.predict_regions(region_idx=["chr1:1000-1600", "chr2:2000-2600"])


### PR DESCRIPTION
- removed incorrect return None that caused only one test metric to be logged and the return_metrics to not work
- added unit test that checks for this