### PR TITLE
correctly adjust bed file if outside of chromsizes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "seaborn",
     "pooch",
     "scanpy"
+    "biothings_client<0.4.0",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "pybigtools>=0.2.0",
     "seaborn",
     "pooch",
-    "scanpy"
+    "scanpy",
     "biothings_client<0.4.0",
 ]
 


### PR DESCRIPTION
adata.X matrix shape was not matching up with length of .var_names if regions were outside chromosome sizes during import_bigwigs.
Fixed here by always creating the temp bed file (where the check for chromsizes happens).