### PR TITLE
add cut site bigwigs

### DIFF
--- a/docs/tutorials/model_training_and_eval.ipynb
+++ b/docs/tutorials/model_training_and_eval.ipynb
@@ -43,6 +43,7 @@
    "source": [
     "from pathlib import Path\n",
     "import numpy as np\n",
+    "\n",
     "%matplotlib inline\n",
     "import matplotlib\n",
     "from sklearn.metrics import pairwise\n",
@@ -66,7 +67,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Download the tutorial data"
+    "Download the tutorial data.  \n",
+    "For this tutorial we will be training on the 'cut sites', but the 'coverage' data are also available (an older version of the tutorial would train on the coverage)."
    ]
   },
   {
@@ -75,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bigwigs_folder, regions_file = crested.get_dataset(\"mouse_cortex_bigwig\")"
+    "bigwigs_folder, regions_file = crested.get_dataset(\"mouse_cortex_bigwig_cut_sites\")"
    ]
   },
   {
@@ -91,12 +93,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bigwigs_folder = (\n",
-    "    \"../../../../mouse/biccn/bigwigs/fragments_bws/\"\n",
-    ")\n",
-    "regions_file = (\n",
-    "    \"../../../..//mouse/biccn/consensus_peaks_inputs.bed\"\n",
-    ")\n",
+    "bigwigs_folder = \"../../../../mouse/biccn/bigwigs/fragments_bws/\"\n",
+    "regions_file = \"../../../..//mouse/biccn/consensus_peaks_inputs.bed\"\n",
     "chromsizes_file = \"../../../..//mouse/biccn/mm.chrom.sizes\""
    ]
   },
@@ -802,7 +800,7 @@
     "    project_name=\"mouse_biccn\",  # change to your liking\n",
     "    run_name=\"basemodel\",  # change to your liking\n",
     "    logger=\"wandb\",  # or 'wandb', 'tensorboard'\n",
-    "    seed=7,# For reproducibility\n",
+    "    seed=7,  # For reproducibility\n",
     ")"
    ]
   },
@@ -1527,7 +1525,8 @@
    "source": [
     "# First load the pretrained model on all peaks\n",
     "model_architecture = keras.models.load_model(\n",
-    "    \"mouse_biccn/basemodel/checkpoints/17.keras\", compile=False # Choose the basemodel with best validation loss/performance metrics\n",
+    "    \"mouse_biccn/basemodel/checkpoints/17.keras\",\n",
+    "    compile=False,  # Choose the basemodel with best validation loss/performance metrics\n",
     ")"
    ]
   },

--- a/src/crested/_datasets.py
+++ b/src/crested/_datasets.py
@@ -39,7 +39,8 @@ def _get_dataset_index():
             ## For datasets at the CREsted resources, a relative URL as name is sufficient. For an external dataset, add the absolute URL to `urls = {'name': 'https://thefullurl.eu/yourfile.txt'}`.
             registry={
                 # BICCN datasets
-                "data/mouse_biccn/bigwigs.tar.gz": "sha256:738504d26b864de10804978b4b47196094996174349c1140e44824ce6d0349ba",
+                "data/mouse_biccn/bigwigs_coverage.tar.gz": "sha256:738504d26b864de10804978b4b47196094996174349c1140e44824ce6d0349ba",
+                "data/mouse_biccn/bigwigs_cut_sites.tar.gz": "sha256:0a9871d75a1c03fdfe353171d6cebec307cd96d054594d28b95ee451f948e7f0",
                 "data/mouse_biccn/beds.tar.gz": "sha256:0a2c42505eaced286a731c15a10ec63b680a90333a47de4a3c86a112e4e0f8df",
                 "data/mouse_biccn/consensus_peaks_biccn.bed": "sha256:83ce5a58aee11c40d7a1e11b603ceb34012e0e4b91eea0953eb37a943707a1e5",
                 # Melanoma datasets
@@ -75,7 +76,8 @@ def get_dataset(dataset: str):
 
     Provided examples:
     - 'mouse_cortex_bed': the BICCN mouse cortex snATAC-seq dataset, processed as BED files per topic. For use in topic classification.
-    - 'mouse_cortex_bigwig': the BICCN mouse cortex snATAC-seq dataset, processed as pseudobulked bigWig tracks per cell type. For use in peak regression.
+    - 'mouse_cortex_bigwig_coverage': the BICCN mouse cortex snATAC-seq dataset, processed as pseudobulked bigWig coverage tracks per cell type. For use in peak regression.
+    - 'mouse_cortex_bigwig_cut_sites': the BICCN mouse cortex snATAC-seq dataset, processed as pseudobulked bigWig cut site tracks per cell type. For use in peak regression.
 
     These two paths can be passed to :func:`crested.import_bigwigs()` / :func:`crested.import_beds()`.
 
@@ -87,7 +89,11 @@ def get_dataset(dataset: str):
     ----------
     dataset
         The name of the dataset to fetch.
-        Options: 'mouse_cortex_bed', 'mouse_cortex_bigwig'
+        Options:
+            - 'mouse_cortex_bed'
+            - 'mouse_cortex_bigwig_cut_sites'
+            - 'mouse_cortex_bigwig_coverage'
+            - 'mouse_cortex_bigwig' (deprecated, same as 'mouse_cortex_bigwig_coverage')
 
     Returns
     -------
@@ -104,10 +110,18 @@ def get_dataset(dataset: str):
             "data/mouse_biccn/beds.tar.gz",
             "data/mouse_biccn/consensus_peaks_biccn.bed",
         ),
-        "mouse_cortex_bigwig": (
-            "data/mouse_biccn/bigwigs.tar.gz",
+        "mouse_cortex_bigwig_coverage": (
+            "data/mouse_biccn/bigwigs_coverage.tar.gz",
             "data/mouse_biccn/consensus_peaks_biccn.bed",
         ),
+        "mouse_cortex_bigwig_cut_sites": (
+            "data/mouse_biccn/bigwigs_cut_sites.tar.gz",
+            "data/mouse_biccn/consensus_peaks_biccn.bed",
+        ),
+        "mouse_cortex_bigwig": (
+            "data/mouse_biccn/bigwigs_coverage.tar.gz",
+            "data/mouse_biccn/consensus_peaks_biccn.bed",
+        ),  # Deprecated
     }
     assert (
         dataset in dataset_mapping


### PR DESCRIPTION
Two new bigwigs options in crested.get_dataset():
-  'mouse_cortex_bigwig_cut_sites'
-  'mouse_cortex_bigwig_coverage'

Previous 'mouse_cortex_bigwig' is still available for backwards compatibility reasons but returns exact same as the 'coverage' version.

Updated tutorial notebook to use 'cut_sites' option.

