### PR TITLE
More explainer changes

### DIFF
--- a/src/crested/tl/_explainer.py
+++ b/src/crested/tl/_explainer.py
@@ -14,9 +14,25 @@ import numpy as np
 from crested.utils._seq_utils import generate_mutagenesis
 
 if os.environ["KERAS_BACKEND"] == "tensorflow":
-    from crested.tl._explainer_tf import _saliency_map, _smoothgrad, function_batch
+    from tensorflow import Tensor
+
+    from crested.tl._explainer_tf import (
+        _from_tensor,
+        _is_tensor,
+        _saliency_map,
+        _smoothgrad,
+        _to_tensor,
+    )
 elif os.environ["KERAS_BACKEND"] == "torch":
-    from crested.tl._explainer_torch import _saliency_map, _smoothgrad, function_batch
+    from torch import Tensor
+
+    from crested.tl._explainer_torch import (
+        _from_tensor,
+        _is_tensor,
+        _saliency_map,
+        _smoothgrad,
+        _to_tensor,
+    )
 
 # ---- Explainer functions ----
 def saliency_map(
@@ -25,7 +41,6 @@ def saliency_map(
         class_index: int | None,
         batch_size: int = 128,
         func: Callable = None,
-        low_gpu: bool = False
     ) -> np.ndarray:
     """Calculate saliency maps for a given (set of) sequence(s).
 
@@ -51,7 +66,6 @@ def saliency_map(
         model=model,
         class_index=class_index,
         func=func,
-        low_gpu=low_gpu
     )
 
 def integrated_grad(
@@ -64,7 +78,6 @@ def integrated_grad(
         func: Callable = None,
         batch_size: int = 128,
         seed: int = 42,
-        low_gpu: bool = False
     ) -> np.ndarray:
     """Average integrated gradients across different backgrounds.
 
@@ -163,7 +176,6 @@ def integrated_grad(
             class_index=class_index,
             func=func,
             batch_size=batch_size,
-            low_gpu=low_gpu
         )
         # Reshape from n_baselines*n_steps, seq_len, 4 to n_baselines, n_steps, seq_len, 4
         grad = grad.reshape([num_baselines, num_steps+1, x.shape[-2], x.shape[-1]])
@@ -240,7 +252,6 @@ def smoothgrad(
         mean: float = 0.0,
         stddev: float = 0.1,
         func: Callable = None,
-        low_gpu: bool = False
     ) -> np.ndarray:
     """Calculate smoothgrad for a given (set of) sequence(s)."""
     return function_batch(
@@ -253,7 +264,6 @@ def smoothgrad(
         stddev=stddev,
         class_index=class_index,
         func=func,
-        low_gpu=low_gpu
     )
 
 # ---- Helper functions ----
@@ -322,3 +332,59 @@ def random_shuffle(
             shuffle = rng.permutation(x.shape[-2])
             x_shuffle[seq_i, sample_i, :, :] = x[shuffle, :]
     return x_shuffle
+
+def function_batch(
+        X: np.ndarray | Tensor,
+        fun: Callable[[Tensor], Tensor],
+        batch_size: int = 128,
+        **kwargs
+    ) -> np.ndarray:
+    """Run a function in batches.
+
+    Parameters
+    ----------
+    X
+        Sequence inputs, of shape (batch, ...). Can be numpy array or tf/torch tensor.
+    fun
+        A function that takes a tf.Tensor and returns a tf.Tensor of gradients/importances of the same shape.
+    model
+        Your Keras model.
+    batch_size
+        Batch size to use when calculating gradients with the model.
+        Default is 128.
+    kwargs
+        Passed to fun().
+
+    Returns
+    -------
+    Numpy array of the same shape as X.
+    """
+    data_size = X.shape[0]
+    # If fits in one batch, return directly
+    if data_size <= batch_size:
+        if not _is_tensor(X):
+            X = _to_tensor(X)
+        grads = fun(X, **kwargs)
+        return _from_tensor(grads)
+    # Else, loop for as many batches as needed
+    else:
+        outputs = []
+        # Get batch indices
+        n_batches = data_size // batch_size
+        batch_idxes = [(i*batch_size, (i+1)*batch_size) for i in range(n_batches)]
+        if data_size % batch_size > 0:
+            batch_idxes.append((batch_idxes[-1][1], data_size))
+
+        # Loop over batches
+        for batch_start, batch_end in batch_idxes:
+            # Get inputs
+            batch = X[batch_start:batch_end, ...]
+            if not _is_tensor(batch):
+                batch = _to_tensor(batch)
+            # Calculate gradients for batch
+            grads = fun(batch, **kwargs)
+            # Save gradients
+            outputs.append(_from_tensor(grads))
+
+        # Return outputs
+        return np.concatenate(outputs, axis=0)

--- a/src/crested/tl/_explainer.py
+++ b/src/crested/tl/_explainer.py
@@ -57,11 +57,11 @@ def integrated_grad(
         model: keras.Model,
         class_index: int | None = None,
         baseline_type: str = "random",
-        num_baselines: int =25,
-        num_steps: int =25,
+        num_baselines: int = 25,
+        num_steps: int = 25,
         func: Callable = None,
         batch_size: int = 128,
-        seed: int =42,
+        seed: int = 42,
     ) -> np.ndarray:
     """Average integrated gradients across different backgrounds.
 

--- a/src/crested/tl/_explainer.py
+++ b/src/crested/tl/_explainer.py
@@ -24,7 +24,8 @@ def saliency_map(
         model: keras.Model,
         class_index: int | None,
         batch_size: int = 128,
-        func: Callable = None
+        func: Callable = None,
+        low_gpu: bool = False
     ) -> np.ndarray:
     """Calculate saliency maps for a given (set of) sequence(s).
 
@@ -50,6 +51,7 @@ def saliency_map(
         model=model,
         class_index=class_index,
         func=func,
+        low_gpu=low_gpu
     )
 
 def integrated_grad(
@@ -62,6 +64,7 @@ def integrated_grad(
         func: Callable = None,
         batch_size: int = 128,
         seed: int = 42,
+        low_gpu: bool = False
     ) -> np.ndarray:
     """Average integrated gradients across different backgrounds.
 
@@ -160,6 +163,7 @@ def integrated_grad(
             class_index=class_index,
             func=func,
             batch_size=batch_size,
+            low_gpu=low_gpu
         )
         # Reshape from n_baselines*n_steps, seq_len, 4 to n_baselines, n_steps, seq_len, 4
         grad = grad.reshape([num_baselines, num_steps+1, x.shape[-2], x.shape[-1]])
@@ -235,7 +239,8 @@ def smoothgrad(
         num_samples: int = 50,
         mean: float = 0.0,
         stddev: float = 0.1,
-        func: Callable = None
+        func: Callable = None,
+        low_gpu: bool = False
     ) -> np.ndarray:
     """Calculate smoothgrad for a given (set of) sequence(s)."""
     return function_batch(
@@ -248,6 +253,7 @@ def smoothgrad(
         stddev=stddev,
         class_index=class_index,
         func=func,
+        low_gpu=low_gpu
     )
 
 # ---- Helper functions ----

--- a/src/crested/tl/_explainer_tf.py
+++ b/src/crested/tl/_explainer_tf.py
@@ -19,7 +19,23 @@ def _saliency_map(
         class_index: int | None = None,
         func: Callable[[tf.Tensor], tf.Tensor] = tf.math.reduce_mean
     ) -> tf.Tensor:
-    """Fast function to generate saliency maps."""
+    """Fast function to generate saliency maps.
+
+    Parameters
+    ----------
+    X
+        tf.Tensor of sequences/model inputs, of shape (n_sequences, seq_len, nuc).
+    model
+        Your Keras model, or any object that supports __call__ with gradients, so it can also be a non-Keras TensorFlow model.
+    class_index
+        Index of model output to explain. Model assumed to return outputs of shape (batch_size, n_classes) if using this.
+    func
+        Function to reduce model outputs to one value with, if not using class_index.
+
+    Returns
+    -------
+    Gradients of the same shape as X, (batch, seq_len, nuc).
+    """
     if func is None:
         func = tf.math.reduce_mean
     with tf.GradientTape() as tape:

--- a/src/crested/tl/_explainer_torch.py
+++ b/src/crested/tl/_explainer_torch.py
@@ -19,7 +19,23 @@ def _saliency_map(
         class_index: int | None = None,
         func: Callable[[torch.Tensor], torch.Tensor] = torch.mean
     ) -> torch.Tensor:
-    """Fast function to generate saliency maps."""
+    """Fast function to generate saliency maps.
+
+    Parameters
+    ----------
+    X
+        torch.Tensor of sequences/model inputs, of shape (n_sequences, seq_len, nuc).
+    model
+        Your Keras model, or any object that supports __call__ with gradients, so it can also be a non-Keras PyTorch model.
+    class_index
+        Index of model output to explain. Model assumed to return outputs of shape (batch_size, n_classes) if using this.
+    func
+        Function to reduce model outputs to one value with, if not using class_index.
+
+    Returns
+    -------
+    Gradients of the same shape as X, (batch, seq_len, nuc).
+    """
     if func is None:
         func = torch.mean
     X = X.clone().detach().requires_grad_(True)

--- a/src/crested/tl/_explainer_torch.py
+++ b/src/crested/tl/_explainer_torch.py
@@ -49,66 +49,12 @@ def _smoothgrad(
     grad = _saliency_map(x_noise, model, class_index=class_index, func=func)
     return torch.mean(grad, dim=0, keepdim=True).numpy()
 
-def function_batch(
-        X: np.ndarray | torch.Tensor,
-        fun: Callable[[torch.Tensor], torch.Tensor],
-        batch_size: int = 128,
-        low_gpu: bool = False,
-        **kwargs
-    ) -> np.ndarray:
-    """Run a function in batches.
+def _is_tensor(array) -> bool:
+    return torch.is_tensor(array)
 
-    Parameters
-    ----------
-    X
-        Sequence inputs, of shape (batch, ...). Can be numpy array or torch tensor.
-    fun
-        A function that takes a torch.Tensor and returns a torch.Tensor of gradients/importances of the same shape.
-    model
-        Your Keras model.
-    batch_size
-        Batch size to use when calculating gradients with the model.
-        Default is 128.
-    low_gpu
-        Move each batch to/from CPU separately, instead of whole input and output array. Saves GPU memory, but reduces speed.
-    kwargs
-        Passed to fun().
+def _to_tensor(array: np.array) -> torch.Tensor:
+    return torch.from_numpy(array)
 
-    Returns
-    -------
-    Numpy array of the same shape as X.
-    """
-    # If low_gpu: convert to/from numpy+cpu at batch level for inputs & outputs
-    # Else: convert to/from numpy+cpu at X level for inputs & outputs
+def _from_tensor(tensor: torch.Tensor) -> np.array:
+    return tensor.detach().cpu().numpy()
 
-    if not low_gpu and not torch.is_tensor(X):
-        X = torch.from_numpy(X)
-
-    data_size = X.shape[0]
-    # If fits in one batch, return directly
-    if data_size <= batch_size:
-        return fun(X, **kwargs).detach().cpu().numpy()
-    # Else, loop for as many batches as needed
-    else:
-        # Save outputs to numpy array (if low_gpu) or tf.Tensor (if not low_gpu)
-        outputs = np.zeros_like(X) if low_gpu else torch.zeros_like(X)
-
-        # Get batch indices
-        n_batches = data_size // batch_size
-        batch_idxes = [(i*batch_size, (i+1)*batch_size) for i in range(n_batches)]
-        if data_size % batch_size > 0:
-            batch_idxes.append((batch_idxes[-1][1], data_size))
-
-        # Loop over batches
-        for batch_start, batch_end in batch_idxes:
-            # Get inputs
-            batch = X[batch_start:batch_end, ...]
-            if low_gpu and not torch.is_tensor():
-                batch = torch.from_numpy(batch)
-            # Calculate gradients for batch
-            grads = fun(batch, **kwargs)
-            # Save gradients
-            outputs[batch_start:batch_end, ...] = grads.detach().cpu().numpy() if low_gpu else grads.detach()
-
-        # Return outputs, converting to CPU if not low_gpu
-        return outputs if low_gpu else outputs.cpu().numpy()

--- a/src/crested/tl/_explainer_torch.py
+++ b/src/crested/tl/_explainer_torch.py
@@ -85,8 +85,7 @@ def function_batch(
         outputs = np.zeros_like(X)
         n_batches = data_size // batch_size
         for batch_i in range(n_batches):
-            batch_start = (batch_i-1)*batch_size
-            batch_end = batch_i*batch_size
+            batch_start, batch_end = batch_i*batch_size, (batch_i+1)*batch_size
             outputs[batch_start:batch_end, ...] = fun(X[batch_start:batch_end, ...], **kwargs).detach().cpu().numpy()
         if (n_batches % X.shape[0]) > 0:
             outputs[batch_end:, ...] = fun(X[batch_end: , ...], **kwargs).detach().cpu().numpy()

--- a/src/crested/tl/_tools.py
+++ b/src/crested/tl/_tools.py
@@ -267,7 +267,6 @@ def contribution_scores(
     transpose: bool = False,
     all_class_names: list[str] | None = None,
     batch_size: int = 128,
-    low_gpu: bool = False,
     output_dir: os.PathLike | None = None,
     seed: int | None = 42,
     verbose: bool = True,
@@ -356,7 +355,6 @@ def contribution_scores(
                     num_baselines=1,
                     num_steps=25,
                     batch_size=batch_size,
-                    low_gpu = low_gpu
                 )
             elif method == "mutagenesis":
                 scores[:, i, :, :] = mutagenesis(
@@ -374,7 +372,6 @@ def contribution_scores(
                     num_baselines=25,
                     num_steps=25,
                     batch_size=batch_size,
-                    low_gpu=low_gpu,
                     seed=seed,
                 )
             elif method == "saliency_map":
@@ -383,7 +380,6 @@ def contribution_scores(
                     model=m,
                     class_index=class_index,
                     batch_size=batch_size,
-                    low_gpu=low_gpu
                 )
             else:
                 raise ValueError(f"Unsupported method: {method}")
@@ -426,7 +422,6 @@ def contribution_scores_specific(
     method: str = "expected_integrated_grad",
     transpose: bool = True,
     batch_size: int = 128,
-    low_gpu: bool = False,
     output_dir: os.PathLike | None = None,
     verbose: bool = True,
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -507,7 +502,6 @@ def contribution_scores_specific(
             verbose=verbose,
             output_dir=output_dir,
             batch_size=batch_size,
-            low_gpu=low_gpu,
             all_class_names=all_class_names,
             transpose=transpose,
         )

--- a/src/crested/tl/_tools.py
+++ b/src/crested/tl/_tools.py
@@ -267,6 +267,7 @@ def contribution_scores(
     transpose: bool = False,
     all_class_names: list[str] | None = None,
     batch_size: int = 128,
+    low_gpu: bool = False,
     output_dir: os.PathLike | None = None,
     seed: int | None = 42,
     verbose: bool = True,
@@ -354,7 +355,8 @@ def contribution_scores(
                     baseline_type="zeros",
                     num_baselines=1,
                     num_steps=25,
-                    batch_size=batch_size
+                    batch_size=batch_size,
+                    low_gpu = low_gpu
                 )
             elif method == "mutagenesis":
                 scores[:, i, :, :] = mutagenesis(
@@ -372,14 +374,16 @@ def contribution_scores(
                     num_baselines=25,
                     num_steps=25,
                     batch_size=batch_size,
-                    seed=seed
+                    low_gpu=low_gpu,
+                    seed=seed,
                 )
             elif method == "saliency_map":
                 scores[:, i, :, :] = saliency_map(
                     input_sequences,
                     model=m,
                     class_index=class_index,
-                    batch_size=batch_size
+                    batch_size=batch_size,
+                    low_gpu=low_gpu
                 )
             else:
                 raise ValueError(f"Unsupported method: {method}")
@@ -422,6 +426,7 @@ def contribution_scores_specific(
     method: str = "expected_integrated_grad",
     transpose: bool = True,
     batch_size: int = 128,
+    low_gpu: bool = False,
     output_dir: os.PathLike | None = None,
     verbose: bool = True,
 ) -> tuple[np.ndarray, np.ndarray]:
@@ -502,6 +507,7 @@ def contribution_scores_specific(
             verbose=verbose,
             output_dir=output_dir,
             batch_size=batch_size,
+            low_gpu=low_gpu,
             all_class_names=all_class_names,
             transpose=transpose,
         )


### PR DESCRIPTION
I was still running out of GPU memory for expected integrated gradients and Borzoi, even when getting gradients for one sequence. Figured out that it was loading the 650 sequences into GPU memory, and that didn't fit next to the calculations, even if we immediately took the gradients off the GPU. Thought I'd tested all combinations, turns out I didn't.

This rework has tested all three explainers (saliency_map, integrated_grad and expected_integrated_grad) for DilatedCNN (3 seqs & 500 seqs) & Borzoi (3 seqs), for both TensorFlow and PyTorch. 

It moved to appending gradient batches to list and concatenating (since that's what keras' model.predict() also does, and it's just as fast as writing to pre-made array). It also only explicitly moves one batch of sequences to tensor/GPU at a time (Tested against doing it all at once, see #114 , didn't make a difference). Finally, I generalised `function_batch` and made it a backend-agnostic function. 