### PR TITLE
Raise error in locus plotting when highlighted positions are out of range

### DIFF
--- a/src/crested/pl/locus/_locus_scoring.py
+++ b/src/crested/pl/locus/_locus_scoring.py
@@ -82,6 +82,15 @@ def locus_scoring(
 
     .. image:: ../../../../docs/_static/img/examples/locus_locus_scoring.png
     """
+    # Validate highlight_positions to ensure they fall within the specified range.
+    if highlight_positions:
+        for pos in highlight_positions:
+            start, end = pos
+            if start < range[0] or end > range[1]:
+                raise ValueError(
+                    f"Highlighted position ({start}, {end}) falls outside the plotting range {range}."
+                )
+
     # Plotting predictions
     plt.figure(figsize=figsize)
 


### PR DESCRIPTION
Added validation logic for the `highlight_positions` parameter in the `locus_scoring` function. The function now raises a ValueError when any highlight position falls outside the specified genomic range.