### PR TITLE
faster sequence loader from anndata in _transform_input

### DIFF
--- a/src/crested/utils/_utils.py
+++ b/src/crested/utils/_utils.py
@@ -159,7 +159,7 @@ def _transform_input(input, genome: Genome | os.PathLike | None = None) -> np.nd
         genome = _resolve_genome(genome)
         sequences = [
             genome.fetch(chrom, start, end)
-            for chrom, start, end in zip(adata.var['chr'], adata.var['start'], adata.var['end'])
+            for chrom, start, end in zip(input.var['chr'], input.var['start'], input.var['end'])
         ]
     elif input_type == "region":
         genome = _resolve_genome(genome)

--- a/src/crested/utils/_utils.py
+++ b/src/crested/utils/_utils.py
@@ -157,8 +157,10 @@ def _transform_input(input, genome: Genome | os.PathLike | None = None) -> np.nd
 
     if input_type == "anndata":
         genome = _resolve_genome(genome)
-        regions = list(input.var_names)
-        sequences = [genome.fetch(region=region) for region in regions]
+        sequences = [
+            genome.fetch(chrom, start, end)
+            for chrom, start, end in zip(adata.var['chr'], adata.var['start'], adata.var['end'])
+        ]
     elif input_type == "region":
         genome = _resolve_genome(genome)
         regions = input if isinstance(input, list) else [input]


### PR DESCRIPTION
Before using the var names was a lot slower for more exotic chromosomes.
Just getting chrom, start, and end is a lot faster