### PR TITLE
avoiding GPU OOM errors with crested.tl.predict on large datasets

### DIFF
--- a/src/crested/_genome.py
+++ b/src/crested/_genome.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import errno
 import os
 from pathlib import Path
+from functools import cached_property
 
 from loguru import logger
 from pysam import FastaFile
@@ -89,7 +90,7 @@ class Genome:
 
         self._name = name
 
-    @property
+    @cached_property
     def fasta(self) -> FastaFile:
         """
         The pysam FastaFile object for the FASTA file.

--- a/src/crested/_genome.py
+++ b/src/crested/_genome.py
@@ -4,8 +4,8 @@ from __future__ import annotations
 
 import errno
 import os
-from pathlib import Path
 from functools import cached_property
+from pathlib import Path
 
 from loguru import logger
 from pysam import FastaFile

--- a/src/crested/pl/patterns/_utils.py
+++ b/src/crested/pl/patterns/_utils.py
@@ -100,10 +100,13 @@ def _plot_attribution_map(
 
     # Render the plot as an image
     temp_fig.canvas.draw()
+    renderer = temp_fig.canvas.get_renderer()
     width, height = map(int, temp_fig.get_size_inches() * temp_fig.get_dpi())
-    image = np.frombuffer(temp_fig.canvas.tostring_rgb(), dtype="uint8").reshape(
-        height, width, 3
-    )
+    image = np.frombuffer(renderer.buffer_rgba(), dtype="uint8").reshape(height, width, 4)[..., :3]
+    #width, height = map(int, temp_fig.get_size_inches() * temp_fig.get_dpi())
+    #image = np.frombuffer(temp_fig.canvas.tostring_rgb(), dtype="uint8").reshape(
+    #    height, width, 3
+    #)
     plt.close(temp_fig)  # Close the temporary figure to avoid memory leaks
 
     # Rotate the rendered image

--- a/src/crested/tl/_tools.py
+++ b/src/crested/tl/_tools.py
@@ -71,15 +71,52 @@ def extract_layer_embeddings(
     return embeddings
 
 class PredictPyDataset(keras.utils.PyDataset):
+    """
+    A Keras-compatible dataset for batched prediction.
+
+    Wraps an array-like input (e.g., one-hot encoded sequences) and yields batches for model prediction.
+    """
+
     def __init__(self, input_array, batch_size=128):
+        """
+        Initialize the prediction dataset.
+
+        Parameters
+        ----------
+        input_array : array-like
+            Input data, typically a NumPy array of shape (N, L, 4).
+        batch_size : int, optional
+            Number of samples per batch. Default is 128.
+        """
         super().__init__()
         self.input_array = input_array
         self.batch_size = batch_size
 
     def __len__(self):
+        """
+        Return the number of batches.
+
+        Returns
+        -------
+        int
+            Total number of batches per epoch.
+        """
         return math.ceil(len(self.input_array) / self.batch_size)
 
     def __getitem__(self, idx):
+        """
+        Retrieve a single batch of data.
+
+        Parameters
+        ----------
+        idx : int
+            Index of the batch.
+
+        Returns
+        -------
+        array-like
+            A batch of input data.
+        """
         low = idx * self.batch_size
         high = min(low + self.batch_size, len(self.input_array))
         batch = self.input_array[low:high]

--- a/src/crested/tl/_tools.py
+++ b/src/crested/tl/_tools.py
@@ -129,7 +129,7 @@ def predict(
                 preds = _batched_predict(input, m, manual_batch_size, **kwargs)
             else:
                 preds = m.predict(input, **kwargs)
-            all_predictions.append(predictions)
+            all_predictions.append(preds)
 
         averaged_predictions = np.mean(all_predictions, axis=0)
         return averaged_predictions

--- a/src/crested/tl/_tools.py
+++ b/src/crested/tl/_tools.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 from typing import Any
 
@@ -10,7 +11,6 @@ import numpy as np
 from anndata import AnnData
 from loguru import logger
 from tqdm import tqdm
-import math
 
 from crested._genome import Genome
 from crested.tl._explainer import integrated_grad, mutagenesis, saliency_map
@@ -95,18 +95,20 @@ def predict(
 ) -> None | np.ndarray:
     """
     Make predictions using the model(s) on some input that represents sequences.
+
     If a list of models is provided, the predictions will be averaged across all models.
 
     Parameters
     ----------
     input
-        Input data to make predictions on. Can be a (list of) sequence(s), a (list of) region name(s), a matrix of one hot encodings (N, L, 4), or an AnnData object with region names as its var_names.
+        Input data to make predictions on. Can be a (list of) sequence(s), a (list of) region name(s),
+        a matrix of one hot encodings (N, L, 4), or an AnnData object with region names as its var_names.
     model
         A (list of) trained keras model(s) to make predictions with.
     genome
         Genome or path to the genome file. Required if no genome is registered and input is an anndata object or region names.
     batch_size
-        Batch size to use for predictions. 
+        Batch size to use for predictions.
     **kwargs
         Additional keyword arguments to pass to the keras.Model.predict method.
 

--- a/src/crested/tl/modisco/_tfmodisco.py
+++ b/src/crested/tl/modisco/_tfmodisco.py
@@ -1188,6 +1188,12 @@ def find_pattern_matches(
         pattern_ids = []
         for j, pattern in enumerate(all_patterns[p_idx]["instances"]):
             df_motif_database = read_html_to_dataframe(html_paths[i][j])
+            if not isinstance(df_motif_database, pd.DataFrame):
+                logger.warning(
+                    f"Skipping pattern match: expected DataFrame but got {type(df_motif_database).__name__}.\n"
+                    f"Problematic HTML path: {html_path}"
+                )
+                continue
             pattern_id_whole = all_patterns[p_idx]["instances"][pattern]["id"]
             pattern_id_parts = pattern_id_whole.split("_")
             pattern_id = (
@@ -1381,6 +1387,8 @@ def create_tf_ct_matrix(
     total_tf_patterns = sum(len(pattern_tf_dict[p]["tfs"]) for p in pattern_tf_dict)
     tf_ct_matrix = np.zeros((len(classes), total_tf_patterns, 2))
     tf_pattern_annots = []
+
+    df = df.reindex(classes) # Ensure they are in same order.
 
     if pattern_parameter not in ["contrib", "seqlet_count", "seqlet_count_log"]:
         logger.info("Pattern parameter not valid. Setting to default ('seqlet_count').")

--- a/src/crested/tl/modisco/_tfmodisco.py
+++ b/src/crested/tl/modisco/_tfmodisco.py
@@ -1191,7 +1191,7 @@ def find_pattern_matches(
             if not isinstance(df_motif_database, pd.DataFrame):
                 logger.warning(
                     f"Skipping pattern match: expected DataFrame but got {type(df_motif_database).__name__}.\n"
-                    f"Problematic HTML path: {html_path}"
+                    f"Problematic HTML path: {html_paths[i][j]}"
                 )
                 continue
             pattern_id_whole = all_patterns[p_idx]["instances"][pattern]["id"]

--- a/src/crested/tl/modisco/_tfmodisco.py
+++ b/src/crested/tl/modisco/_tfmodisco.py
@@ -541,19 +541,6 @@ def post_hoc_merging(
     if verbose:
         print(f"Total iterations: {iterations}")
 
-    # Debugging step to check for any remaining patterns exceeding the similarity threshold
-    for i, (idx1, _) in enumerate(final_patterns.items()):
-        for j, (idx2, _) in enumerate(final_patterns.items()):
-            if i >= j:
-                continue
-
-            sim = pattern_similarity(final_patterns, idx1, idx2)
-
-            if sim > sim_threshold:
-                print(
-                    f"Warning: Patterns {idx1} and {idx2} exceed similarity threshold with similarity {sim}"
-                )
-
     return final_patterns
 
 

--- a/src/crested/utils/_utils.py
+++ b/src/crested/utils/_utils.py
@@ -154,7 +154,6 @@ def _transform_input(input, genome: Genome | os.PathLike | None = None) -> np.nd
     One-hot encoded matrix of shape (N, L, 4), where N is the number of sequences/regions and L is the sequence length.
     """
     input_type = _detect_input_type(input)
-    from tqdm import tqdm
     if input_type == "anndata":
         genome = _resolve_genome(genome)
         sequences = [

--- a/src/crested/utils/_utils.py
+++ b/src/crested/utils/_utils.py
@@ -154,7 +154,7 @@ def _transform_input(input, genome: Genome | os.PathLike | None = None) -> np.nd
     One-hot encoded matrix of shape (N, L, 4), where N is the number of sequences/regions and L is the sequence length.
     """
     input_type = _detect_input_type(input)
-
+    from tqdm import tqdm
     if input_type == "anndata":
         genome = _resolve_genome(genome)
         sequences = [


### PR DESCRIPTION
when you do crested.tl.predict() on a large dataset, it throws OOM errors because it first copies the whole thing to GPU. Workaround is to do manual batching which can be set quite big. None default so just for edge cases. 