### PR TITLE
Change temp file creation while importing bigwigs

### DIFF
--- a/src/crested/_io.py
+++ b/src/crested/_io.py
@@ -284,7 +284,7 @@ def _create_temp_bed_file(
     adjusted_peaks[2] = adjusted_peaks[2].astype(int)
 
     # Create a temporary BED file
-    temp_bed_file = "temp_adjusted_regions.bed"
+    temp_bed_file = tempfile.NamedTemporaryFile(delete=False, mode="w+t")
     adjusted_peaks.to_csv(temp_bed_file, sep="\t", header=False, index=False)
     return temp_bed_file
 


### PR DESCRIPTION
The old tempfile creation with a fixed name becomes problematic when importing bigwigs in parallel (for training more than one model etc.) in the same folder.