### PR TITLE
Allow single string model_name for plotting functions

### DIFF
--- a/src/crested/pl/bar/_region.py
+++ b/src/crested/pl/bar/_region.py
@@ -14,7 +14,7 @@ from crested.utils._logging import log_and_raise
 def region_predictions(
     adata: AnnData,
     region: str,
-    model_names: list[str] | None = None,
+    model_names: str | list[str] | None = None,
     share_y: bool = True,
     **kwargs,
 ) -> plt.Figure:
@@ -28,7 +28,7 @@ def region_predictions(
     region
         String in the format 'chr:start-end' representing the genomic location.
     model_names
-        List of model names in `adata.layers`. If None, will create a plot per model in `adata.layers`.
+        Single model name or list of model names in `adata.layers`. If None, will create a plot per model in `adata.layers`.
     share_y
         Whether to rescale the y-axis to be the same across plots. Default is True.
     kwargs
@@ -63,10 +63,12 @@ def region_predictions(
                 if model_name not in adata.layers:
                     raise ValueError(f"Model {model_name} not found in adata.layers.")
 
-    _check_input_params()
-
-    if model_names is None:
+    if isinstance(model_names, str):
+        model_names = [model_names]
+    elif model_names is None:
         model_names = list(adata.layers.keys())
+
+    _check_input_params()
 
     logger.info(f"Plotting bar plots for region: {region}, models: {model_names}")
 

--- a/src/crested/pl/heatmap/_correlations.py
+++ b/src/crested/pl/heatmap/_correlations.py
@@ -95,7 +95,7 @@ def correlations_self(
 
 def correlations_predictions(
     adata: AnnData,
-    model_names: list[str] | None = None,
+    model_names: str | list[str] | None = None,
     split: str | None = "test",
     log_transform: bool = False,
     vmin: float | None = None,
@@ -111,7 +111,7 @@ def correlations_predictions(
     adata
         AnnData object containing the data in `X` and predictions in `layers`.
     model_names
-        List of model names (adata.layers) to plot for predictions heatmap. Default is to plot all models in `adata.layers`.
+        Model name or list of model names (adata.layers) to plot for predictions heatmap. Default is to plot all models in `adata.layers`.
     split
         'train', 'val', 'test' subset or None. If None, will use all targets. If not None, expects a "split" column in adata.var.
     log_transform
@@ -164,12 +164,14 @@ def correlations_predictions(
             if split not in ["train", "val", "test", None]:
                 raise ValueError("Split must be 'train', 'val', 'test', or None.")
 
-    _check_input_params()
-
     classes = list(adata.obs_names)
 
-    if model_names is None:
+    if isinstance(model_names, str):
+        model_names = [model_names]
+    elif model_names is None:
         model_names = list(adata.layers.keys())
+
+    _check_input_params()
 
     logger.info(
         f"Plotting heatmap correlations for split: {split}, models: {model_names}"

--- a/src/crested/pl/scatter/_class_density.py
+++ b/src/crested/pl/scatter/_class_density.py
@@ -17,7 +17,7 @@ from crested.utils._logging import log_and_raise
 def class_density(
     adata: AnnData,
     class_name: str | None = None,
-    model_names: list[str] | None = None,
+    model_names: str | list[str] | None = None,
     split: str | None = "test",
     log_transform: bool = False,
     exclude_zeros: bool = True,
@@ -37,7 +37,7 @@ def class_density(
     class_name
         Name of the class in `adata.obs_names`. If None, plot is made for all the classes.
     model_names
-        List of model names in `adata.layers`. If None, will create a plot per model in `adata.layers`.
+        Model name or list of model names in `adata.layers`. If None, will create a plot per model in `adata.layers`.
     split
         'train', 'val', 'test' subset or None. If None, will use all targets. If not None, expects a "split" column in adata.var.
     log_transform
@@ -93,14 +93,17 @@ def class_density(
         if split not in ["train", "val", "test", None]:
             raise ValueError("Split must be 'train', 'val', 'test', or None.")
 
+    if isinstance(model_names, str):
+        model_names = [model_names]
+    elif model_names is None:
+        model_names = list(adata.layers.keys())
+
     _check_input_params()
 
     classes = list(adata.obs_names)
     column_index = (
         classes.index(class_name) if class_name else np.arange(0, len(classes))
     )
-    if model_names is None:
-        model_names = list(adata.layers.keys())
 
     if split is not None:
         x = adata[:, adata.var["split"] == split].X[column_index, :].flatten()

--- a/src/crested/pl/violin/_correlations.py
+++ b/src/crested/pl/violin/_correlations.py
@@ -80,11 +80,11 @@ def correlations(
                 raise ValueError("Split must be 'train', 'val', 'test', or None.")
 
     # Validate inputs
-    if model_names is not None and isinstance(model_names, str):
+    if isinstance(model_names, str):
         model_names = [model_names]
-    _check_input_params()
-    if model_names is None:
+    elif model_names is None:
         model_names = list(adata.layers.keys())
+    _check_input_params()
 
     # Gather ground truth and prediction data
     if split is not None:


### PR DESCRIPTION
- Allow for use of a single string for a single model name in all plotting functions that take `model_name` (this previously gave a hard-to-parse error, since it looped over the individual letters in the string)