### PR TITLE
higher scanpy version and restrict to python<3.14 (due to pysam)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,13 +14,12 @@ maintainers = [
 authors = [
   { name = "Stein Aerts Lab" },
 ]
-requires-python = ">=3.11"
+requires-python = ">=3.11,<3.14"
 classifiers = [
   "Programming Language :: Python :: 3 :: Only",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
   "anndata",
@@ -33,7 +32,7 @@ dependencies = [
   "pooch",
   "pybigtools>=0.2",
   "pysam",
-  "scanpy",
+  "scanpy>=1.10",
   "scikit-learn",
   "seaborn",
   "tqdm",


### PR DESCRIPTION
Fix tests failing due to numba/scanpy versioning issues
- increase scanpy version. Don't understand why this was neccessary, UV should have been using the highest possible anyway...
- restrict to python<3.14 since pysam can't handle that one yet