### PR TITLE
Fix genome.fetch not working with start=0

### DIFF
--- a/src/crested/_genome.py
+++ b/src/crested/_genome.py
@@ -199,6 +199,10 @@ class Genome:
             raise ValueError(
                 "chrom/start/end must all be provided or extracted from `region` to extract a sequence."
             )
+        if start == end:
+            raise ValueError(
+                f"Cannot return 0-length sequences (start {start} is same as end {end}).  Did you accidentally input the same value twice?"
+            )
 
         seq = self.fasta.fetch(reference=chrom, start=start, end=end)
         if strand == "-":


### PR DESCRIPTION
Does what it says on the tin. When using `genome.fetch()` with a zero coordinate, this was read as False in the 'do all values exist'-check. That check should explicitly be against None instead, which is what it was intended to check.

Also adds a zero-length sequence check, just for those cases you accidentally copy-paste the end in place of the start and don't notice what's going on.