### PR TITLE
Squeeze out dimension added in modern anndata

### DIFF
--- a/src/crested/pl/bar/_normalization_weights.py
+++ b/src/crested/pl/bar/_normalization_weights.py
@@ -47,7 +47,7 @@ def normalization_weights(adata: AnnData, **kwargs) -> plt.Figure:
 
     _check_input_params()
 
-    weights = adata.obsm["weights"]
+    weights = adata.obsm["weights"].squeeze()
     classes = list(adata.obs_names)
 
     fig, ax = plt.subplots()


### PR DESCRIPTION
Not sure when this changed, but it seems modern versions of `anndata` force `obsm` entries to be 2D. Our `adata.obsm['weights']` was previously 1D (`(n_obs,)`), but now it's turned into a `(n_obs, 1)` matrix after adding it to the adata. `crested.pl.bar.normalization_weights()` depended on it being 1D, so squeezing it fixes the problem. 

I checked and the actual X values don't seem to be affected (nor do the values of the normalization weights), it's really just the shape. I noticed this in the plotting tests I'm adding in #166, where it fails for all python versions. It doesn't fail in my existing local environment, but it does in a newly created one, so that's why I'm assuming it's to do with a new anndata version (since I also checked that the calculated matrix before putting it into the anndata is still 1D).