### PR TITLE
Undo deleting tarball after extracting since it re-downloads every time

### DIFF
--- a/src/crested/_datasets.py
+++ b/src/crested/_datasets.py
@@ -158,7 +158,7 @@ def get_dataset(dataset: str):
     )
     targets_url, cregions_url = dataset_mapping[dataset]
     targets_paths = _get_dataset_index().fetch(
-        targets_url, processor=UntarDelete(), progressbar=True
+        targets_url, processor=pooch.Untar(), progressbar=True
     )
     cregions_path = _get_dataset_index().fetch(cregions_url, progressbar=True)
     targets_dir = os.path.dirname(targets_paths[0])


### PR DESCRIPTION
Merged this too hastily in #180. The deleting works, but Pooch (understandably) doesn't recognise the extracted data as it being present, only the original tarball. That makes sense, since it can't calculate a hash from the extracted folder to check whether it's been updated and needs to be re-downloaded either.

Theoretically we could devise a system that stores the hash of the tarball to a txt file and then deletes the tarball, so that we can use the stored hash as reference. That's not supported in current Pooch however, and  don't feel like implementing all of that manually atm.