### PR TITLE
Add motif dependencies to py3.11 and py3.12 tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,7 +96,7 @@ run = "pytest -v --cov --color=yes {args}"
 [[tool.hatch.envs.hatch-test.matrix]]
 python = [ "3.11", "3.12"]
 backend = [ "tensorflow", "pytorch" ]
-feature = [ "motif" ]
+optional_deps = [ "motif" ]
 
 [[tool.hatch.envs.hatch-test.matrix]]
 python = [ "3.13" ]
@@ -107,6 +107,10 @@ matrix.backend.extra-dependencies = [
   { value = "tensorflow", if = [ "tensorflow" ] },
   { value = "torch", if = [ "pytorch" ] },
 ]
+matrix.optional_deps.features = [
+  { value = "motif", if = [ "motif" ] },
+]
+
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
We currently don't test installing and running `crested[motif]` at all. I wrote a few tests that run if those dependencies are installed, so here's an attempt to make hatch do that in the environment matrix.