### PR TITLE
202603 bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,13 +93,13 @@ For questions and help requests, please use the [issue tracker][issue-tracker].
 
 ## Citation
 
-Kempynck, N., De Winter, S., et al. [CREsted: modeling genomic and synthetic cell type-specific enhancers across tissues and species.](https://www.biorxiv.org/content/10.1101/2025.04.02.646812v1)
+Kempynck, N., De Winter, S., et al. [CREsted: modeling genomic and synthetic cell type-specific enhancers across tissues and species.](https://www.nature.com/articles/s41592-026-03057-2)
 
 We also store CREsted version backups on Zenodo: [https://doi.org/10.5281/zenodo.15045960](https://doi.org/10.5281/zenodo.15045960)
 
 ## Choosing your backend
 
-CREsted is build on top of keras 3.0 and can therefore be used with your deep learning backend of choice (TensorFlow or PyTorch). If you don't have a preference, you can take the following into account:
+CREsted is build on top of Keras 3.0 and can therefore be used with your deep learning backend of choice (TensorFlow or PyTorch). If you don't have a preference, you can take the following into account:
 
 1. From our (and Keras' official) benchmarking, **TensorFlow** is generally faster than PyTorch for training (up to 2x) since TensorFlow operates in graph mode whereas PyTorch uses eager mode. If you plan on training many models, TensorFlow might be the better choice.
 2. **PyTorch** is easier to debug and get going. TensorFlow will easily throw a bunch of warnings or fail to detect CUDA if you don't have the exact right versions of CUDA and cuDNN installed. PyTorch seems more lenient in this regard. If you only plan on running predictions or training a few models, PyTorch might be the easier choice.

--- a/docs/models/BICCN/borzoi_biccn.rst
+++ b/docs/models/BICCN/borzoi_biccn.rst
@@ -25,7 +25,7 @@ Details of the data and the model can be found in the original publication. The 
 
 .. admonition:: Citation
 
-   Kempynck, N., De Winter, S., et al. CREsted: modeling genomic and synthetic cell type-specific enhancers across tissues and species. bioRxiv (2025). https://doi.org/10.1101/2025.04.02.646812
+   Kempynck, N., De Winter, S. et al. CREsted: modeling genomic and synthetic cell-type-specific enhancers across tissues and species. Nature Methods (2026). https://doi.org/10.1038/s41592-026-03057-2
 
 .. admonition:: Data source
 

--- a/docs/models/BICCN/deepbiccn.rst
+++ b/docs/models/BICCN/deepbiccn.rst
@@ -22,7 +22,7 @@ Details of the data and the model can be found in the original publication.
 
 .. admonition:: Citation
 
-    Johansen, N.J., Kempynck, N. et al. Evaluating Methods for the Prediction of Cell Type-Specific Enhancers in the Mammalian Cortex. Cell Genomics (2025). https://doi.org/10.1016/j.xgen.2025.100879
+    Johansen, N.J., Kempynck, N. et al. Evaluating methods for the prediction of cell-type-specific enhancers in the mammalian cortex. Cell Genomics (2025). https://doi.org/10.1016/j.xgen.2025.100879
 
 .. admonition:: Data source
 

--- a/docs/models/BICCN/deepbiccn2.rst
+++ b/docs/models/BICCN/deepbiccn2.rst
@@ -22,7 +22,7 @@ Details of the data and the model can be found in the original publication.
 
 .. admonition:: Citation
 
-   Kempynck, N., De Winter, S., et al. CREsted: modeling genomic and synthetic cell type-specific enhancers across tissues and species. bioRxiv (2025). https://doi.org/10.1101/2025.04.02.646812
+   Kempynck, N., De Winter, S. et al. CREsted: modeling genomic and synthetic cell-type-specific enhancers across tissues and species. Nature Methods (2026). https://doi.org/10.1038/s41592-026-03057-2
 
 .. admonition:: Data source
 

--- a/docs/models/BICCN/mousecortex_hydrop.rst
+++ b/docs/models/BICCN/mousecortex_hydrop.rst
@@ -22,7 +22,7 @@ Details of the data and the model can be found in the original publication.
 
 .. admonition:: Citation
 
-   Dickmanken, H., Wojno, M., Theunis, K., Eksi, E. C., Mahieu, L., Christiaens, V., Kempynck, N., De Rop, F., Roels, N., Spanier, K. I., Vandepoel, R., Hulselmans, G., Poovathingal, S., Aerts, S. HyDrop v2: Scalable atlas construction for training sequence-to-function models. bioRxiv (2025). https://doi.org/10.1101/2025.04.02.646792
+   Dickmänken, H. et al. Evaluating single-cell ATAC-seq atlasing technologies using sequence-to-function modeling. Nature Communications 17, 1951 (2026). https://doi.org/10.1038/s41467-026-68742-4
 
 Usage
 -------------------

--- a/docs/models/Brain/deepmousebrain1.rst
+++ b/docs/models/Brain/deepmousebrain1.rst
@@ -27,7 +27,7 @@ Details of the data and the model can be found in the original publication.
 
 .. admonition:: Data source
 
-    Bravo González-Blas, C., De Winter, S., et al. SCENIC+: single-cell multiomic inference of enhancers and gene regulatory networks. Nat Methods (2023). https://doi.org/10.1038/s41592-023-01938-4
+    Bravo González-Blas, C., De Winter, S., et al. SCENIC+: single-cell multiomic inference of enhancers and gene regulatory networks. Nature Methods (2023). https://doi.org/10.1038/s41592-023-01938-4
 
 Usage
 -------------------

--- a/docs/models/Cancer/deepccl.rst
+++ b/docs/models/Cancer/deepccl.rst
@@ -22,7 +22,7 @@ Details of the data and the model can be found in the original publication.
 
 .. admonition:: Citation
 
-   Kempynck, N., De Winter, S., et al. CREsted: modeling genomic and synthetic cell type-specific enhancers across tissues and species. bioRxiv (2025). https://doi.org/10.1101/2025.04.02.646812
+   Kempynck, N., De Winter, S. et al. CREsted: modeling genomic and synthetic cell-type-specific enhancers across tissues and species. Nature Methods (2026). https://doi.org/10.1038/s41592-026-03057-2
 
 Usage
 -------------------

--- a/docs/models/Cancer/deepglioma.rst
+++ b/docs/models/Cancer/deepglioma.rst
@@ -22,7 +22,7 @@ Details of the data and the model can be found in the original publication.
 
 .. admonition:: Citation
 
-   Kempynck, N., De Winter, S., et al. CREsted: modeling genomic and synthetic cell type-specific enhancers across tissues and species. bioRxiv (2025). https://doi.org/10.1101/2025.04.02.646812
+   Kempynck, N., De Winter, S. et al. CREsted: modeling genomic and synthetic cell-type-specific enhancers across tissues and species. Nature Methods (2026). https://doi.org/10.1038/s41592-026-03057-2
 
 .. admonition:: Data source
 

--- a/docs/models/Cancer/deepmel1.rst
+++ b/docs/models/Cancer/deepmel1.rst
@@ -25,7 +25,7 @@ Details of the data and model can be found in the original publication.
 
 .. admonition:: Citation
 
-    Minoye, L., Taskiran, I.I. et al. Cross-species analysis of enhancer logic using deep learning. Genome Res. 30, 1815–1834 (2020). https://doi.org/10.1101/gr.260844.120
+    Minoye, L., Taskiran, I.I. et al. Cross-species analysis of enhancer logic using deep learning. Genome Research 30, 1815–1834 (2020). https://doi.org/10.1101/gr.260844.120
 
 Usage
 -------------------

--- a/docs/models/Cancer/deepmel2.rst
+++ b/docs/models/Cancer/deepmel2.rst
@@ -26,7 +26,7 @@ Details of the data and model can be found in the original publication.
 
 .. admonition:: Citation
 
-    Atak, Z.K., Taskiran, I.I. et al. Interpretation of allele-specific chromatin accessibility using cell state-aware deep learning. Genome Res. 31, 1082–1096 (2021). https://doi.org/10.1101/gr.260851.120
+    Atak, Z.K., Taskiran, I.I. et al. Interpretation of allele-specific chromatin accessibility using cell state-aware deep learning. Genome Research 31, 1082–1096 (2021). https://doi.org/10.1101/gr.260851.120
 
 Usage
 -------------------

--- a/docs/models/Cancer/deepmel2_gabpa.rst
+++ b/docs/models/Cancer/deepmel2_gabpa.rst
@@ -20,7 +20,7 @@ Details of the data and model can be found in the original publication.
 
 .. admonition:: Citation
 
-    Atak, Z.K., Taskiran, I.I. et al. Interpretation of allele-specific chromatin accessibility using cell state-aware deep learning. Genome Res. 31, 1082–1096 (2021). https://doi.org/10.1101/gr.260851.120
+    Atak, Z.K., Taskiran, I.I. et al. Interpretation of allele-specific chromatin accessibility using cell state-aware deep learning. Genome Research 31, 1082–1096 (2021). https://doi.org/10.1101/gr.260851.120
 
 Usage
 -------------------

--- a/docs/models/EnformerBorzoi/borzoi.rst
+++ b/docs/models/EnformerBorzoi/borzoi.rst
@@ -31,7 +31,7 @@ Details of the data and the model can be found in the original publication.
 
 .. admonition:: Citation
 
-    Linder, J., Srivastava, D., Yuan, H. et al. Predicting RNA-seq coverage from DNA sequence as a unifying model of gene regulation. Nat Genet (2025). https://doi.org/10.1038/s41588-024-02053-6
+    Linder, J. et al. Predicting RNA-seq coverage from DNA sequence as a unifying model of gene regulation. Nature Genetics (2025). https://doi.org/10.1038/s41588-024-02053-6
 
 .. admonition:: License
 

--- a/docs/models/EnformerBorzoi/enformer.rst
+++ b/docs/models/EnformerBorzoi/enformer.rst
@@ -30,7 +30,7 @@ Details of the data and the model can be found in the original publication.
 
 .. admonition:: Citation
 
-    Avsec, Ž., Agarwal, V., Visentin, D. et al. Effective gene expression prediction from sequence by integrating long-range interactions. Nat Methods 18, 1196–1203 (2021). https://doi.org/10.1038/s41592-021-01252-x
+    Avsec, Ž. et al. Effective gene expression prediction from sequence by integrating long-range interactions. Nature Methods 18, 1196–1203 (2021). https://doi.org/10.1038/s41592-021-01252-x
 
 .. admonition:: License
 

--- a/docs/models/Fly/embryo_10x.rst
+++ b/docs/models/Fly/embryo_10x.rst
@@ -28,7 +28,7 @@ Details of the data and the model can be found in the original publication.
 
 .. admonition:: Citation
 
-   Dickmanken, H., Wojno, M., Theunis, K., Eksi, E. C., Mahieu, L., Christiaens, V., Kempynck, N., De Rop, F., Roels, N., Spanier, K. I., Vandepoel, R., Hulselmans, G., Poovathingal, S., Aerts, S. HyDrop v2: Scalable atlas construction for training sequence-to-function models. bioRxiv (2025). https://doi.org/10.1101/2025.04.02.646792
+   Dickmänken, H. et al. Evaluating single-cell ATAC-seq atlasing technologies using sequence-to-function modeling. Nature Communications 17, 1951 (2026). https://doi.org/10.1038/s41467-026-68742-4
 
 Usage
 -------------------

--- a/docs/models/Fly/embryo_hydrop.rst
+++ b/docs/models/Fly/embryo_hydrop.rst
@@ -28,7 +28,7 @@ Details of the data and the model can be found in the original publication.
 
 .. admonition:: Citation
 
-   Dickmanken, H., Wojno, M., Theunis, K., Eksi, E. C., Mahieu, L., Christiaens, V., Kempynck, N., De Rop, F., Roels, N., Spanier, K. I., Vandepoel, R., Hulselmans, G., Poovathingal, S., Aerts, S. HyDrop v2: Scalable atlas construction for training sequence-to-function models. bioRxiv (2025). https://doi.org/10.1101/2025.04.02.646792
+   Dickmänken, H. et al. Evaluating single-cell ATAC-seq atlasing technologies using sequence-to-function modeling. Nature Communications 17, 1951 (2026). https://doi.org/10.1038/s41467-026-68742-4
 
 Usage
 -------------------

--- a/docs/models/Liver/deepliver accessibility.rst
+++ b/docs/models/Liver/deepliver accessibility.rst
@@ -22,7 +22,7 @@ Details of the data and model can be found in the original publication.
 
 .. admonition:: Citation
 
-    Bravo González-Blas, C., Matetovici, I., Hillen, H. et al. Single-cell spatial multi-omics and deep learning dissect enhancer-driven gene regulatory networks in liver zonation. Nat Cell Biol 26, 153-167 (2024). https://doi.org/10.1038/s41556-023-01316-4
+    Bravo González-Blas, C. et al. Single-cell spatial multi-omics and deep learning dissect enhancer-driven gene regulatory networks in liver zonation. Nature Cell Biology 26, 153-167 (2024). https://doi.org/10.1038/s41556-023-01316-4
 
 Usage
 -------------------

--- a/docs/models/Liver/deepliver activity.rst
+++ b/docs/models/Liver/deepliver activity.rst
@@ -21,7 +21,7 @@ Details of the data and model can be found in the original publication.
 
 .. admonition:: Citation
 
-    Bravo González-Blas, C., Matetovici, I., Hillen, H. et al. Single-cell spatial multi-omics and deep learning dissect enhancer-driven gene regulatory networks in liver zonation. Nat Cell Biol 26, 153-167 (2024). https://doi.org/10.1038/s41556-023-01316-4
+    Bravo González-Blas, C. et al. Single-cell spatial multi-omics and deep learning dissect enhancer-driven gene regulatory networks in liver zonation. Nature Cell Biology 26, 153-167 (2024). https://doi.org/10.1038/s41556-023-01316-4
 
 Usage
 -------------------

--- a/docs/models/Liver/deepliver zonation.rst
+++ b/docs/models/Liver/deepliver zonation.rst
@@ -20,7 +20,7 @@ Details of the data and model can be found in the original publication.
 
 .. admonition:: Citation
 
-    Bravo González-Blas, C., Matetovici, I., Hillen, H. et al. Single-cell spatial multi-omics and deep learning dissect enhancer-driven gene regulatory networks in liver zonation. Nat Cell Biol 26, 153-167 (2024). https://doi.org/10.1038/s41556-023-01316-4
+    Bravo González-Blas, C. et al. Single-cell spatial multi-omics and deep learning dissect enhancer-driven gene regulatory networks in liver zonation. Nature Cell Biology 26, 153-167 (2024). https://doi.org/10.1038/s41556-023-01316-4
 
 Usage
 -------------------

--- a/docs/models/deeppbmc.rst
+++ b/docs/models/deeppbmc.rst
@@ -22,7 +22,7 @@ Details of the data and the model can be found in the original publication.
 
 .. admonition:: Citation
 
-   Kempynck, N., De Winter, S., et al. CREsted: modeling genomic and synthetic cell type-specific enhancers across tissues and species. bioRxiv (2025). https://doi.org/10.1101/2025.04.02.646812
+   Kempynck, N., De Winter, S. et al. CREsted: modeling genomic and synthetic cell-type-specific enhancers across tissues and species. Nature Methods (2026). https://doi.org/10.1038/s41592-026-03057-2
 
 .. admonition:: Data source
 

--- a/docs/models/deepzebrafish.rst
+++ b/docs/models/deepzebrafish.rst
@@ -23,7 +23,7 @@ Details of the data and the model can be found in the original publication.
 
 .. admonition:: Citation
 
-   Kempynck, N., De Winter, S., et al. CREsted: modeling genomic and synthetic cell type-specific enhancers across tissues and species. bioRxiv (2025). https://doi.org/10.1101/2025.04.02.646812
+   Kempynck, N., De Winter, S. et al. CREsted: modeling genomic and synthetic cell-type-specific enhancers across tissues and species. Nature Methods (2026). https://doi.org/10.1038/s41592-026-03057-2
 
 .. admonition:: Data source
 

--- a/src/crested/pl/corr/_heatmap.py
+++ b/src/crested/pl/corr/_heatmap.py
@@ -155,8 +155,6 @@ def heatmap_self(
     # Set defaults
     if 'xtick_rotation' not in kwargs:
         kwargs['xtick_rotation'] = 90
-    if 'layout' not in kwargs:
-        kwargs['layout'] = 'compressed'
     plot_kws = {} if plot_kws is None else plot_kws.copy() # Most plot defaults handled in _generate_heatmap() defaults
     cbar_kws = {} if cbar_kws is None else cbar_kws.copy()
     if 'label' not in cbar_kws:
@@ -175,7 +173,7 @@ def heatmap_self(
 
     # Plot heatmap
     default_width = 10 if cbar else 8
-    fig, ax = create_plot(ax=ax, kwargs_dict=kwargs, default_width=default_width, default_height=8)
+    fig, ax = create_plot(ax=ax, kwargs_dict=kwargs, default_width=default_width, default_height=8, default_layout='compressed')
     ax = _generate_heatmap(ax=ax, correlation_matrix=correlation_matrix, classes=classes, vmin=vmin, vmax=vmax, reorder=reorder, cmap=cmap, cbar=cbar, cbar_kws=cbar_kws, **plot_kws)
 
     return render_plot(fig, ax, **kwargs)
@@ -291,8 +289,6 @@ def heatmap(
     # Set defaults
     if 'xtick_rotation' not in kwargs:
         kwargs['xtick_rotation'] = 90
-    if 'layout' not in kwargs:
-        kwargs['layout'] = 'compressed'
     if 'title' not in kwargs:
         kwargs['title'] = list(model_names)
     plot_kws = {} if plot_kws is None else plot_kws.copy() # Most plot defaults handled in _generate_heatmap() defaults
@@ -309,7 +305,7 @@ def heatmap(
 
     # Create plots
     default_width = 10*n_models if cbar else 8*n_models
-    fig, axs = create_plot(ax=ax, kwargs_dict=kwargs, default_width=default_width, default_height=8, ncols=n_models)
+    fig, axs = create_plot(ax=ax, kwargs_dict=kwargs, default_width=default_width, default_height=8, ncols=n_models, default_layout='compressed')
     if isinstance(axs, plt.Axes):
         axs = [axs]
 

--- a/src/crested/tl/_crested.py
+++ b/src/crested/tl/_crested.py
@@ -8,16 +8,10 @@ import shutil
 from datetime import datetime
 
 import keras
-import numpy as np
-from anndata import AnnData
 from loguru import logger
 
 from crested.tl import TaskConfig
 from crested.tl.data import AnnDataModule
-from crested.tl.data._dataset import SequenceLoader
-from crested.utils import (
-    one_hot_encode_sequence,
-)
 from crested.utils._logging import log_and_raise
 
 
@@ -564,74 +558,6 @@ class Crested:
             return evaluation_metrics
         return None
 
-    def _create_random_sequences(self, n_sequences: int, seq_len: int) -> np.ndarray:
-        if self.acgt_distribution is None:
-            self._calculate_location_gc_frequencies()
-
-        random_sequences = np.empty((n_sequences), dtype=object)
-
-        for idx_seq in range(n_sequences):
-            current_sequence = []
-            for idx_loc in range(seq_len):
-                current_sequence.append(
-                    np.random.choice(
-                        ["A", "C", "G", "T"], p=list(self.acgt_distribution[idx_loc])
-                    )
-                )
-            random_sequences[idx_seq] = "".join(current_sequence)
-
-        return random_sequences
-
-    def _parse_starting_sequences(self, starting_sequences) -> np.ndarray:
-        if isinstance(starting_sequences, str):
-            starting_sequences = [starting_sequences]
-
-        n_sequences = len(starting_sequences)
-        starting_sequences_array = np.empty((n_sequences), dtype=object)
-        for idx, sequence in enumerate(starting_sequences):
-            starting_sequences_array[idx] = sequence
-
-        return starting_sequences_array
-
-    def _calculate_location_gc_frequencies(self) -> np.ndarray:
-        regions = self.anndatamodule.adata.var
-        sequence_loader = SequenceLoader(
-            genome=self.anndatamodule.genome,
-            in_memory=True,
-            always_reverse_complement=False,
-            max_stochastic_shift=0,
-            regions=list(regions.index),
-        )
-        all_sequences = list(sequence_loader.sequences.values())
-        sequence_length = len(all_sequences[0])
-        all_onehot_squeeze = np.array(
-            [one_hot_encode_sequence(seq) for seq in all_sequences]
-        ).squeeze(axis=1)
-        acgt_distribution = np.sum(all_onehot_squeeze, axis=0).astype(int) / np.reshape(
-            np.sum(np.sum(all_onehot_squeeze, axis=0), axis=1), (sequence_length, 1)
-        ).astype(int)
-
-        self.acgt_distribution = acgt_distribution
-        return acgt_distribution
-
-    def _derive_intermediate_sequences(self, enhancer_design_intermediate):
-        all_designed_list = []
-        for intermediate_dict in enhancer_design_intermediate:
-            current_sequence = intermediate_dict["initial_sequence"]
-            sequence_list = [current_sequence]
-            for loc, change in intermediate_dict["changes"]:
-                if loc == -1:
-                    continue
-                else:
-                    current_sequence = (
-                        current_sequence[:loc]
-                        + change
-                        + current_sequence[loc + len(change) :]
-                    )
-                    sequence_list.append(current_sequence)
-            all_designed_list.append(sequence_list)
-        return all_designed_list
-
     @staticmethod
     def _check_gpu_availability():
         """Check if GPUs are available."""
@@ -651,19 +577,6 @@ class Crested:
                 logger.warning("No GPUs available, falling back to CPU.")
                 devices = keras.distribution.list_devices("cpu")
             return devices
-
-    @log_and_raise(ValueError)
-    def _check_contrib_params(self, method):
-        if method not in [
-            "integrated_grad",
-            "smooth_grad",
-            "mutagenesis",
-            "saliency",
-            "expected_integrated_grad",
-        ]:
-            raise ValueError(
-                "Contribution score method not implemented. Choose out of the following options: integrated_grad, smooth_grad, mutagenesis, saliency, expected_integrated_grad."
-            )
 
     @log_and_raise(ValueError)
     def _check_fit_params(self):
@@ -691,35 +604,6 @@ class Crested:
             raise ValueError(
                 "Model not set. Please load a model from pretrained using Crested.load_model(...) before calling test."
             )
-
-    @log_and_raise(ValueError)
-    def _check_predict_params(self, anndata: AnnData | None, model_name: str | None):
-        """Check if the necessary parameters are set for the predict method."""
-        if not self.model:
-            raise ValueError(
-                "Model not set. Please load a model from pretrained using Crested.load_model(...) before calling predict."
-            )
-        if (anndata is not None and model_name is None) or (
-            anndata is None and model_name is not None
-        ):
-            raise ValueError(
-                "Both anndata and model_name must be provided if one of them is provided."
-            )
-
-    @log_and_raise(ValueError)
-    def _check_contribution_scores_params(self, class_names: list):
-        """Check if the necessary parameters are set for the calculate_contribution_scores method."""
-        if not self.model:
-            raise ValueError(
-                "Model not set. Please load a model from pretrained using Crested.load_model(...) before calling calculate_contribution_scores_(regions)."
-            )
-
-        all_class_names = list(self.anndatamodule.adata.obs_names)
-        for class_name in class_names:
-            if class_name not in all_class_names:
-                raise ValueError(
-                    f"Class name {class_name} not found in anndata.obs_names."
-                )
 
     def _check_continued_training(self):
         """Check if the model is already trained and load existing model if so."""


### PR DESCRIPTION
Documentation:
- Update links/citations from CREsted preprint to CREsted paper 🎉 
- Update model citations in general for consistency

Bugfixes:
- Move default layout setting from `kwargs['layout']` to `create_plot(default_layout=)` in `crested.pl.heatmap`/`heatmap_self`. Same functionality, just doesn't emit a warning when using a pre-existing plot, and more in line with other plot-creating functionality.
- Remove deprecated internal `Crested` object methods. Their associated public methods were removed in v1.7.1, after already being deprecated in v1.3. I missed the internal 'backend' functions though, but those are thoroughly superseded by the standalone `crested.tl` functions already since v1.3.  