### PR TITLE
Updates for crested.pp.change_regions_width

### DIFF
--- a/src/crested/pp/_regions.py
+++ b/src/crested/pp/_regions.py
@@ -91,13 +91,14 @@ def change_regions_width(
         stranded = True
     else:
         raise ValueError("Region names must follow 'chr:start-end' or 'chr:start-end:strand' layout.")
-    half_width = width / 2
 
     # Copy if doing inplace
     if not inplace:
         adata = adata.copy()
     adata.var = adata.var.copy()
 
+    # Create new values and record spacing for all regions
+    half_width = width / 2
     new_starts, new_ends, new_names = [], [], []
     regions_to_keep = []
     for region_name in adata.var_names:
@@ -121,11 +122,12 @@ def change_regions_width(
             else:
                 regions_to_keep.append(new_name)
 
-    # Rename
+    # Set new values in adata
     adata.var['unresized_index'] = adata.var_names
     adata.var.index = new_names
     adata.var['start'] = new_starts
     adata.var['end'] = new_ends
+    adata.var_names.name = "region"
 
     # Filter out oversized regions
     if chromsizes is not None and (len(regions_to_keep) < len(adata.var_names)):
@@ -134,6 +136,6 @@ def change_regions_width(
         else:
             adata = adata[:, regions_to_keep].copy()
 
-    adata.var_names.name = "region"
+
     if not inplace:
         return adata

--- a/src/crested/pp/_regions.py
+++ b/src/crested/pp/_regions.py
@@ -122,6 +122,7 @@ def change_regions_width(
                 regions_to_keep.append(new_name)
 
     # Rename
+    adata.var['unresized_index'] = adata.var_names
     adata.var.index = new_names
     adata.var['start'] = new_starts
     adata.var['end'] = new_ends

--- a/src/crested/pp/_regions.py
+++ b/src/crested/pp/_regions.py
@@ -9,6 +9,7 @@ import pandas as pd
 from anndata import AnnData
 from loguru import logger
 
+from crested import Genome
 from crested import _conf as conf
 from crested.utils import parse_region
 from crested.utils._logging import log_and_raise
@@ -26,7 +27,7 @@ def _read_chromsizes(chromsizes_file: str | PathLike) -> dict[str, int]:
 def change_regions_width(
     adata: AnnData,
     width: int,
-    chromsizes_file: str | PathLike | None = None,
+    chromsizes_file: str | PathLike | Genome | None = None,
     inplace: bool = True,
 ) -> AnnData | None:
     """
@@ -44,7 +45,7 @@ def change_regions_width(
     width
         The new width of the regions.
     chromsizes_file
-        File path of the chromsizes file. Used for checking if the new regions are within the chromosome boundaries.
+        File path of the chromsizes file or Genome object. Used for checking if the new regions are within the chromosome boundaries.
         If not provided, uses chromsizes from the registered Genome object, and if that doesn't exist either, doesn't check against chromosome boundaries.
     inplace
         Perform computation and modify `adata` in-place or return a resulting copy of the `adata` instead.
@@ -75,7 +76,10 @@ def change_regions_width(
     _check_input_params(chromsizes_file=chromsizes_file)
 
     if chromsizes_file is not None:
-        chromsizes = _read_chromsizes(chromsizes_file)
+        if isinstance(chromsizes_file, Genome):
+            chromsizes = chromsizes_file.chrom_sizes
+        else:
+            chromsizes = _read_chromsizes(chromsizes_file)
     elif conf.genome:
         chromsizes = conf.genome.chrom_sizes
     else:

--- a/src/crested/pp/_regions.py
+++ b/src/crested/pp/_regions.py
@@ -10,6 +10,7 @@ from anndata import AnnData
 from loguru import logger
 
 from crested import _conf as conf
+from crested.utils import parse_region
 from crested.utils._logging import log_and_raise
 
 
@@ -70,6 +71,7 @@ def change_regions_width(
                 stacklevel=1,
             )
 
+    # Handle pre-resizing checks
     _check_input_params(chromsizes_file=chromsizes_file)
 
     if chromsizes_file is not None:
@@ -79,36 +81,53 @@ def change_regions_width(
     else:
         chromsizes = None
 
-    centers = (adata.var["start"] + adata.var["end"]) / 2
+    if adata.var_names[0].count(':') == 1:
+        stranded = False
+    elif adata.var_names[0].count(':') == 2:
+        stranded = True
+    else:
+        raise ValueError("Regions must conat")
     half_width = width / 2
 
+    # Copy if doing inplace
     if not inplace:
         adata = adata.copy()
     adata.var = adata.var.copy()
 
-    adata.var["start"] = (centers - half_width).astype(int)
-    adata.var["end"] = (centers + half_width).astype(int)
+    new_starts, new_ends, new_names = [], [], []
+    regions_to_keep = []
+    for region_name in adata.var_names:
+        # Resize regions
+        chrom, start, end, strand = parse_region(region_name)
+        center = (start + end)/2
+        new_start, new_end = int(center-half_width), int(center+half_width)
+        new_name = f"{chrom}:{int(center-half_width)}-{int(center+half_width)}"
+        if stranded:
+            new_name += f":{strand}"
+        new_starts.append(new_start)
+        new_ends.append(new_end)
+        new_names.append(new_name)
 
-    adata.var_names = adata.var.apply(
-        lambda row: f"{row['chr']}:{row['start']}-{row['end']}", axis=1
-    )
-
-    # Check if regions are within the chromosome boundaries
-    if chromsizes is not None:
-        regions_to_keep = list(adata.var_names.copy())
-        for idx, row in adata.var.iterrows():
-            chr_name = row["chr"]
-            start, end = row["start"], row["end"]
-            if start < 0 or end > chromsizes.get(chr_name, float("inf")):
+        # Check chromosome boundaries
+        if chromsizes is not None:
+            if start < 0 or end > chromsizes.get(chrom, float("inf")):
                 logger.warning(
-                    f"Region {idx} with coordinates {chr_name}:{start}-{end} is out of bounds for chromosome {chr_name}. Removing region."
+                    f"Region {region_name} with new coordinates {chrom}:{new_start}-{new_end} is out of bounds for chromosome {chrom}. Removing region."
                 )
-                regions_to_keep.remove(idx)
-        if len(regions_to_keep) < len(adata.var_names):
-            if inplace:
-                adata._inplace_subset_var(regions_to_keep)
             else:
-                adata = adata[:, regions_to_keep].copy()
+                regions_to_keep.append(new_name)
+
+    # Rename
+    adata.var.index = new_names
+    adata.var['start'] = new_starts
+    adata.var['end'] = new_ends
+
+    # Filter out oversized regions
+    if chromsizes is not None and (len(regions_to_keep) < len(adata.var_names)):
+        if inplace:
+            adata._inplace_subset_var(regions_to_keep)
+        else:
+            adata = adata[:, regions_to_keep].copy()
 
     adata.var_names.name = "region"
     if not inplace:

--- a/src/crested/pp/_regions.py
+++ b/src/crested/pp/_regions.py
@@ -90,7 +90,7 @@ def change_regions_width(
     elif adata.var_names[0].count(':') == 2:
         stranded = True
     else:
-        raise ValueError("Regions must conat")
+        raise ValueError("Region names must follow 'chr:start-end' or 'chr:start-end:strand' layout.")
     half_width = width / 2
 
     # Copy if doing inplace


### PR DESCRIPTION
- Strand info is now preserved if the input regions are stranded
- Now uses region names as ground truth, instead of `adata.var['start'/'end']`.
  - It adjusts both the region name and 'start'/'end', so they will be in sync afterwards. If they were in sync before (which is very likely, since this is one of the first functions you'd call), nothing is changing. 
  - This is the only potentially breaking change. However, it's more consistent and expected behavior given the rest of the package.
  - We should standardize on one place to contain the region coordinates. Since training (and crested.tl.predict) are based on region names, this function now uses them as well. In an ideal world this is a setting the user can change, but that's a future update.
- You can now pass a genome object for `chromsizes_file`. It already recognised a registered genome, but if you were working with multiple genomes, you'd have to dig up the chromsizes path again. Now you can just pass the appropriate genome.
- The old index is now stored in `adata.var['unresized_index']`