### PR TITLE
Read FASTA file first in file cache before using fetch.

### DIFF
--- a/src/crested/_genome.py
+++ b/src/crested/_genome.py
@@ -11,7 +11,7 @@ from loguru import logger
 from pysam import FastaFile
 
 import crested._conf as conf
-from crested.utils._seq_utils import reverse_complement
+from crested.utils._seq_utils import parse_region, reverse_complement
 
 
 class Genome:
@@ -194,11 +194,7 @@ class Genome:
                 "Both region and chrom/start/end supplied. Using chrom/start/end..."
             )
         elif region:
-            if region[-2] == ":":
-                chrom, start_end, strand = region.split(":")
-            else:
-                chrom, start_end = region.split(":")
-            start, end = map(int, start_end.split("-"))
+            chrom, start, end, strand = parse_region(region)
 
         if chrom is None or start is None or end is None:
             raise ValueError(

--- a/src/crested/_genome.py
+++ b/src/crested/_genome.py
@@ -99,6 +99,11 @@ class Genome:
         -------
         The pysam FastaFile object.
         """
+        # Read FASTA file in blocks of 32kb to bring the file in file cache so random access via
+        # `fetch` will be faster on remote file systems.
+        with open(self._fasta, "rb") as fh:
+            for _chunk in fh.read(32768):
+                pass
         return FastaFile(self._fasta)
 
     @property

--- a/src/crested/_genome.py
+++ b/src/crested/_genome.py
@@ -102,7 +102,7 @@ class Genome:
         # Read FASTA file in blocks of 32kb to bring the file in file cache so random access via
         # `fetch` will be faster on remote file systems.
         with open(self._fasta, "rb") as fh:
-            for _chunk in fh.read(32768):
+            for _ in fh.read(32768):
                 pass
         return FastaFile(self._fasta)
 


### PR DESCRIPTION
Read FASTA file first in file cache before using fetch. This will speedup fetching regions later from the FASTA file, on slow remote file systems.