### PR TITLE
fix(pp): check resized coords in change_regions_width boundary filter

### DIFF
--- a/src/crested/pp/_regions.py
+++ b/src/crested/pp/_regions.py
@@ -113,9 +113,11 @@ def change_regions_width(
         new_ends.append(new_end)
         new_names.append(new_name)
 
-        # Check chromosome boundaries
+        # Check chromosome boundaries on the resized coordinates (not the
+        # originals): a region whose centered/widened window runs off a contig
+        # edge must be dropped even if the original peak was in-bounds.
         if chromsizes is not None:
-            if start < 0 or end > chromsizes.get(chrom, float("inf")):
+            if new_start < 0 or new_end > chromsizes.get(chrom, float("inf")):
                 logger.warning(
                     f"Region {region_name} with new coordinates {chrom}:{new_start}-{new_end} is out of bounds for chromosome {chrom}. Removing region."
                 )

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -161,6 +161,29 @@ def test_change_regions_width_inplace(adata_function):
     assert not adata_function.var.equals(adata_copy.var)
 
 
+def test_change_regions_width_drops_resized_out_of_bounds():
+    """Regions whose *resized* window falls off a contig edge must be dropped.
+
+    The original peaks are all within the chromosome, but after widening, the
+    ones near a contig edge run past 0 or past the chromosome length. These must
+    be removed (the boundary check has to use the resized coordinates, not the
+    original ones). chrM in test.chrom.sizes is 16299 bp.
+    """
+    regions = [
+        "chrM:50-150",  # center 100 -> [-957, 1157]: negative start -> drop
+        "chr1:100000-100100",  # center 100050 -> [98993, 101107]: in bounds -> keep
+        "chrM:16200-16280",  # center 16240 -> [15183, 17297]: past end 16299 -> drop
+    ]
+    adata = create_anndata_with_regions(regions)
+
+    crested.pp.change_regions_width(
+        adata, width=2114, chromsizes_file="tests/data/test.chrom.sizes"
+    )
+
+    assert list(adata.var_names) == ["chr1:98993-101107"]
+    assert adata.n_vars == 1
+
+
 # def test_normalization_consistency():
 #     regions = [
 #         "chr1:100-200",


### PR DESCRIPTION
change_regions_width was meant to drop regions whose widened window falls off a contig edge (its warning even reports the new coordinates), but the boundary check tested the original start/end instead of new_start/new_end. Since raw peaks are always within bounds, no out-of-range resized regions were ever filtered, leaving negative-start region names (e.g. 'chr:-907-1207') that break downstream re-parsing and sequence fetching. Most apparent on assemblies with many short scaffolds (e.g. rheMac10).

Check new_start/new_end instead, and add a regression test.