### PR TITLE
Add simplex_correction option to contribution score functions

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,7 @@
 
 ### Features
 - STEAM models (`STEAM_v1`, `STEAM_evolution_aware`, `STEAM_evolution_naive`) from the [evolutionary transfer learning paper](https://doi.org/10.62329/hxkk6249) are now available in the model repository via {func}`crested.get_model`.
+- {func}`crested.tl.contribution_scores` and {func}`crested.tl.contribution_scores_specific` now take a `simplex_correction` argument. When enabled, gradient-based scores are projected back onto the probability simplex by subtracting the per-position mean across the four nucleotide channels, reducing off-simplex noise as proposed in [Majdandzic et al. (2023)](https://doi.org/10.1186/s13059-023-02956-3).
 
 ## 1.8.1
 ### Bugfixes:

--- a/src/crested/tl/_tools.py
+++ b/src/crested/tl/_tools.py
@@ -396,6 +396,7 @@ def contribution_scores(
     batch_size: int = 128,
     output_dir: str | os.PathLike | None = None,
     seed: int | None = 42,
+    simplex_correction: bool = False,
     verbose: bool = True,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
@@ -440,6 +441,16 @@ def contribution_scores(
         Will create a separate npz file per class.
     seed
         Seed to use for shuffling regions. Only used in "expected_integrated_grad".
+    simplex_correction
+        Whether to project the gradients back onto the probability simplex by subtracting,
+        at each position, the mean gradient across the four nucleotide channels
+        (``grad - grad.mean(axis=-1, keepdims=True)``). This removes the component of the
+        gradient that points off the simplex on which one-hot sequences live, reducing
+        spurious noise in the attribution maps, as proposed in Majdandzic et al. (2023),
+        "Correcting gradient-based interpretations of deep neural networks for genomics"
+        (Genome Biology). Only applies to the gradient-based methods ('saliency_map',
+        'integrated_grad', 'expected_integrated_grad'); for other methods it is ignored
+        with a warning.
     verbose
         Boolean for disabling the logs and plotting progress of calculations using tqdm.
 
@@ -451,6 +462,14 @@ def contribution_scores(
     --------
     crested.pl.explain.contribution_scores
     """
+    _gradient_methods = {"saliency_map", "integrated_grad", "expected_integrated_grad"}
+    if simplex_correction and method not in _gradient_methods:
+        logger.warning(
+            f"simplex_correction=True is only meaningful for gradient-based methods "
+            f"({', '.join(sorted(_gradient_methods))}), but method='{method}' was given. "
+            "Ignoring simplex_correction."
+        )
+        simplex_correction = False
 
     @log_and_raise(ValueError)
     def _check_input_params(
@@ -560,6 +579,12 @@ def contribution_scores(
     # Average the scores across models
     averaged_scores = np.mean(scores_per_model, axis=0)  # Shape: (N, C, L, 4)
 
+    # Project gradients back onto the simplex (Majdandzic et al., 2023) by zero-meaning
+    # across the nucleotide axis at each position. Mean-subtraction is linear, so applying
+    # it once on the model-averaged scores is equivalent to applying it per model.
+    if simplex_correction:
+        averaged_scores = averaged_scores - averaged_scores.mean(axis=-1, keepdims=True)
+
     if transpose:
         averaged_scores = np.transpose(averaged_scores, (0, 1, 3, 2))
         input_sequences = np.transpose(input_sequences, (0, 2, 1))
@@ -595,6 +620,7 @@ def contribution_scores_specific(
     batch_size: int = 128,
     output_dir: str | os.PathLike | None = None,
     skip_existing: bool = False,
+    simplex_correction: bool = False,
     verbose: bool = True,
 ) -> tuple[np.ndarray, np.ndarray]:
     """
@@ -637,6 +663,12 @@ def contribution_scores_specific(
     skip_existing
         If writing files by setting `output_dir`, whether to skip calculating contribution scores for classes that have already been written to file.
         By default, re-calculates and overwrites existing files.
+    simplex_correction
+        Whether to project the gradients back onto the probability simplex by subtracting,
+        at each position, the mean gradient across the four nucleotide channels, as proposed
+        in Majdandzic et al. (2023). Only applies to the gradient-based methods
+        ('saliency_map', 'integrated_grad', 'expected_integrated_grad'); for other methods it
+        is ignored with a warning. See :func:`~crested.tl.contribution_scores`.
     verbose
         Boolean for disabling the plotting progress of calculations using tqdm.
 
@@ -683,6 +715,7 @@ def contribution_scores_specific(
             batch_size=batch_size,
             all_class_names=all_class_names,
             transpose=transpose,
+            simplex_correction=simplex_correction,
         )
         all_scores.append(scores)
         all_one_hots.append(one_hots)


### PR DESCRIPTION
Add an optional `simplex_correction` argument (default False) to `contribution_scores` and `contribution_scores_specific`. When enabled, gradient-based scores are projected back onto the probability simplex by subtracting the per-position mean across the four nucleotide channels, removing off-simplex noise as proposed in Majdandzic et al. (2023).

Only applies to gradient methods (saliency_map, integrated_grad, expected_integrated_grad); ignored with a warning for perturbation-based methods. The correction is applied to the raw-gradient scores before the transpose, where axis -1 is the nucleotide channel.