### PR TITLE
docs: clarify CosineMSELogLoss multiplier <-> import target pairing

### DIFF
--- a/src/crested/_io.py
+++ b/src/crested/_io.py
@@ -592,7 +592,15 @@ def import_bigwigs(
         File name of the chromsizes file. Used for checking if the new regions are within the chromosome boundaries.
         If not provided, will look for a registered genome object.
     target
-        Target value to extract from bigwigs. Can be 'mean', 'max', 'count', or 'logcount'
+        Target value to extract from bigwigs. Can be 'mean', 'max', 'count', or 'logcount'.
+        ``'count'`` sums the signal over the region while ``'mean'`` averages it, so
+        ``count == mean * target_region_width``. For dense coverage bigwigs use ``'mean'``;
+        for sparse cut-site bigwigs use ``'count'`` (summing avoids near-zero values).
+        Note: this choice is coupled to the ``multiplier`` of
+        :class:`~crested.tl.losses.CosineMSELogLoss` if you train with it. Pair ``'mean'``
+        targets with ``multiplier=target_region_width`` (1000 by default) and ``'count'``
+        targets with ``multiplier=1``; a mismatch silently collapses the loss' dynamic range.
+        See :func:`~crested.tl.default_configs` ('peak_regression_mean' vs 'peak_regression_count').
     target_region_width
         Width of region that the bigWig target value will be extracted from. If None, the
         consensus region width will be used.

--- a/src/crested/tl/_configs.py
+++ b/src/crested/tl/_configs.py
@@ -210,6 +210,15 @@ def default_configs(
     - "peak_regression_mean" (w/ alias "peak_regression")
     - "peak_regression_count"
 
+    The two peak regression configs differ in the ``multiplier`` of their
+    :class:`~crested.tl.losses.CosineMSELogLoss`, which must match how the targets
+    were imported with :func:`~crested.import_bigwigs`:
+
+    - "peak_regression_mean" uses ``multiplier=1000`` -> pair with ``target='mean'``
+      (dense coverage; assumes ``target_region_width=1000``).
+    - "peak_regression_count" uses ``multiplier=1`` -> pair with ``target='count'``
+      (summed cut sites).
+
     If what you want to do is not supported, you can create your own by using the TaskConfig class.
 
     Example

--- a/src/crested/tl/losses/_cosinemse_log.py
+++ b/src/crested/tl/losses/_cosinemse_log.py
@@ -28,6 +28,18 @@ class CosineMSELogLoss(keras.losses.Loss):
         When predicting mean coverage, we recommend multiplying by number of bp averaged over to get actual counts (1000 by default, also the default here).
         Recommended to keep to 1 when predicting insertion counts.
 
+        This must match how the targets were imported with
+        :func:`~crested.import_bigwigs` (the ``target`` argument):
+
+        - ``target='mean'`` (dense coverage) -> ``multiplier=target_region_width`` (1000 by default)
+        - ``target='count'`` (summed cut sites) -> ``multiplier=1``
+
+        Since ``count == mean * target_region_width``, these two pairings are
+        equivalent and both land the targets in a sensible range for the
+        ``log(1 + multiplier * y)`` transform. A mismatch (e.g. ``'mean'`` values
+        with ``multiplier=1``) leaves ``multiplier * y`` near zero, where ``log1p``
+        is ~linear and the log transform stops doing anything.
+
     Notes
     -----
     - The log transformation is `log(1 + 1000 * y)` for positive values and `-log(1 + abs(1000 * y))` for negative values.


### PR DESCRIPTION
Document that import_bigwigs target='mean' must pair with multiplier= target_region_width (1000) and target='count' with multiplier=1, since count == mean * target_region_width. A mismatch leaves multiplier*y near zero where log1p is ~linear, collapsing the loss' dynamic range.

Cross-referenced across import_bigwigs, CosineMSELogLoss, and default_configs (peak_regression_mean vs peak_regression_count).