### PR TITLE
fix(modisco): resolve find_pattern for instance-only pattern IDs

### DIFF
--- a/src/crested/tl/modisco/_tfmodisco.py
+++ b/src/crested/tl/modisco/_tfmodisco.py
@@ -842,13 +842,17 @@ def find_pattern(pattern_id: str, pattern_dict: dict) -> int | None:
     Returns
     -------
     The index of the pattern if found, otherwise None.
+
+    Notes
+    -----
+    The ``instances`` of each merged pattern contain every ID folded into it,
+    including its own representative and class-representative IDs, so a single
+    scan of ``instances`` matches representatives, class representatives, and
+    instance members alike. Instance IDs are unique across merged patterns.
     """
     for idx, p in enumerate(pattern_dict):
-        if pattern_id == pattern_dict[p]["pattern"]["id"]:
+        if pattern_id in pattern_dict[p]["instances"]:
             return idx
-        for c in pattern_dict[p]["classes"]:
-            if pattern_id == pattern_dict[p]["classes"][c]["id"]:
-                return idx
     return None
 
 


### PR DESCRIPTION
Search each merged pattern's instances instead of only its representative and class-representative IDs. Instances are a superset (they include the representative and class-rep IDs) with globally unique keys, so this also matches pattern IDs folded into a merged pattern as instances, which previously returned None.