### PR TITLE
Fix anndata nonelayer

### DIFF
--- a/src/crested/pl/_old/bar/_bar.py
+++ b/src/crested/pl/_old/bar/_bar.py
@@ -76,12 +76,11 @@ def region_predictions(
     :meta private:
     """
     # Parse model_names into targets tuple
-    if model_names is not None:
-        if isinstance(model_names, str):
+    if model_names is None:
+        model_names = [layer_name for layer_name in adata.layers if layer_name is not None]
+    if isinstance(model_names, str):
             model_names = [model_names]
-        model_names = [*model_names, 'truth']
-    else:
-        model_names = [*adata.layers.keys(), 'truth']
+    model_names += ['truth']
 
     # Deprecation warnings
     targets_string = "None" if model_names is None else model_names

--- a/src/crested/pl/corr/_heatmap.py
+++ b/src/crested/pl/corr/_heatmap.py
@@ -259,6 +259,8 @@ def heatmap(
     def _check_input_params():
         if len(adata.layers) == 0:
             raise ValueError("No predictions found in adata.layers.")
+        if all(layer_name is None for layer_name in adata.layers):
+            raise ValueError("No prediction layers found in adata, only X (ground truth layer).")
 
         for model in model_names:
             if model not in adata.layers:
@@ -280,7 +282,7 @@ def heatmap(
     if isinstance(model_names, str):
         model_names = [model_names]
     elif model_names is None:
-        model_names = list(adata.layers.keys())
+        model_names = [layer_name for layer_name in adata.layers if layer_name is not None]
 
     _check_input_params()
 

--- a/src/crested/pl/corr/_scatter.py
+++ b/src/crested/pl/corr/_scatter.py
@@ -134,7 +134,7 @@ def scatter(
             for model_name in model_names:
                 if model_name not in adata.layers:
                     raise ValueError(f"Model {model_name} not found in adata.layers.")
-        if len(adata.layers) == 0:
+        if len(adata.layers) == 0 or all(layer_name is None for layer_name in adata.layers):
             raise ValueError("Your adata does not contain prediction values. Please add predictions to adata.layers.")
         if split is not None and "split" not in adata.var:
             raise ValueError(
@@ -152,7 +152,7 @@ def scatter(
     if isinstance(model_names, str):
         model_names = [model_names]
     elif model_names is None:
-        model_names = list(adata.layers.keys())
+        model_names = [layer_name for layer_name in adata.layers if layer_name is not None]
 
     _check_input_params()
 

--- a/src/crested/pl/corr/_violin.py
+++ b/src/crested/pl/corr/_violin.py
@@ -72,8 +72,8 @@ def violin(
 
     @log_and_raise(ValueError)
     def _check_input_params():
-        if len(adata.layers) == 0:
-            raise ValueError("No predictions found in adata.layers.")
+        if len(adata.layers) == 0 or all(layer_name is None for layer_name in adata.layers):
+            raise ValueError("Your adata does not contain prediction values. Please add predictions to adata.layers.")
 
         if model_names is not None:
             for model in model_names:
@@ -92,7 +92,7 @@ def violin(
     if isinstance(model_names, str):
         model_names = [model_names]
     elif model_names is None:
-        model_names = list(adata.layers.keys())
+        model_names = [layer_name for layer_name in adata.layers if layer_name is not None]
     n_models = len(model_names)
     _check_input_params()
 

--- a/src/crested/pl/dist/_histogram.py
+++ b/src/crested/pl/dist/_histogram.py
@@ -97,7 +97,7 @@ def histogram(
         if ax is not None and len(class_names) > 1:
             raise ValueError("ax can only be set if plotting one class. Please pick one class in `class_names`.")
 
-    if model_name.lower() in ["x", 'truth', "groundtruth"]:
+    if model_name.lower() in ["x", 'truth', "groundtruth"] or model_name is None:
         model_name = 'truth'
 
     if isinstance(class_names, str):

--- a/src/crested/pl/region/_bar.py
+++ b/src/crested/pl/region/_bar.py
@@ -140,7 +140,7 @@ def bar(
     else:
         # Parse and clean up model_names values
         if model_names is None:
-            model_names = ["truth", *data.layers.keys()]
+            model_names = ["truth"] + [layer_name for layer_name in data.layers if layer_name is not None]
         if isinstance(model_names, str):
             model_names = [model_names]
         model_names = ['truth' if target.lower() in ['x', 'truth', 'groundtruth'] else target for target in model_names]

--- a/src/crested/pl/region/_bar.py
+++ b/src/crested/pl/region/_bar.py
@@ -143,7 +143,7 @@ def bar(
             model_names = ["truth"] + [layer_name for layer_name in data.layers if layer_name is not None]
         if isinstance(model_names, str):
             model_names = [model_names]
-        model_names = ['truth' if target.lower() in ['x', 'truth', 'groundtruth'] else target for target in model_names]
+        model_names = ['truth' if target.lower() in ['x', 'truth', 'groundtruth'] or target is None else target for target in model_names]
         # Check whether params are valid
         _check_adata_params()
         # Gather values

--- a/src/crested/pl/region/_scatter.py
+++ b/src/crested/pl/region/_scatter.py
@@ -90,7 +90,7 @@ def scatter(
         for model_name in model_names:
             if model_name not in adata.layers:
                 raise ValueError(f"Model name {model_name} not found in adata.layers.")
-        if len(adata.layers) == 0:
+        if len(adata.layers) == 0 or all(layer_name is None for layer_name in adata.layers):
             raise ValueError("Your adata does not contain prediction values. Please add predictions to adata.layers.")
         if len(model_names) == 0:
             raise ValueError("No model names found. Either your're providing an empty list or the adata does not contain model names.")
@@ -102,7 +102,7 @@ def scatter(
     if isinstance(model_names, str):
         model_names = [model_names]
     if model_names is None:
-        model_names = list(adata.layers.keys())
+        model_names = [layer_name for layer_name in adata.layers if layer_name is not None]
     n_models = len(model_names)
 
     _check_input_params()


### PR DESCRIPTION
Fixes #225 by skipping layers named `None` when gathering all layers for `model_names`. 

Also adds the option to use `None` for places individual layers are expected (`pl.dist.histogram`, individual arguments of `model_names` for `pl.region.bar`), which was already implemented in other functions (like `pp.filter_regions_on_specificity`).