### PR TITLE
pl.explain.contribution_scores: fix x_shift with coordinates

### DIFF
--- a/src/crested/pl/explain/_contribution_scores.py
+++ b/src/crested/pl/explain/_contribution_scores.py
@@ -230,10 +230,10 @@ def contribution_scores(
 
         # Parse coordinates if supplied
         if coordinates is not None:
-            chrom, start, end, strand = _parse_coordinates_input(coordinates[seq_i])
+            chrom, start, _, strand = _parse_coordinates_input(coordinates[seq_i])
             if zoom_n_bases is not None:
-                start = start + start_idx
-                end = end - start_idx
+                start += start_idx
+                end = start + zoom_n_bases
             left, right = (end, start) if strand == "-" else (start, end)
             default_xlabel = f"{start:,.0f}-{end:,.0f}:{strand} ({np.abs(end - start)} bp)"
             for _ in range(total_classes-1):

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -548,6 +548,65 @@ def test_patterns_contribution_scores_x_shift():
             show=False
         )
 
+def test_patterns_contribution_scores_coordinates():
+    scores = np.random.uniform(-1, 3, (1, 1, 100, 4))
+    seqs_one_hot = np.eye(4)[None, np.random.randint(4, size=100)]
+
+    # Valid plot with positive coordinates as string
+    fig, ax = crested.pl.explain.contribution_scores(
+        scores,
+        seqs_one_hot,
+        coordinates="chr1:100-200:+",
+        show=False
+    )
+    assert fig is not None and ax is not None
+    plt.close()
+
+    # Valid plot with positive coordinates as tuple and zoom
+    fig, ax = crested.pl.explain.contribution_scores(
+        scores,
+        seqs_one_hot,
+        zoom_n_bases=50,
+        coordinates=('chr1', 100, 200),
+        show=False
+    )
+    assert fig is not None and ax is not None
+    plt.close()
+
+    # Valid plot with negative coordinates
+    fig, ax = crested.pl.explain.contribution_scores(
+        scores,
+        seqs_one_hot,
+        coordinates="chr1:100-200:-",
+        show=False
+    )
+    assert fig is not None and ax is not None
+    plt.close()
+
+    # Valid plot with positive coordinates, zoom, and x_shift
+    fig, ax = crested.pl.explain.contribution_scores(
+        scores,
+        seqs_one_hot,
+        coordinates="chr1:100-200:+",
+        zoom_n_bases=50,
+        x_shift=20,
+        show=False
+    )
+    assert fig is not None and ax is not None
+    plt.close()
+
+    # Valid plot with negative coordinates, zoom, and x_shift
+    fig, ax = crested.pl.explain.contribution_scores(
+        scores,
+        seqs_one_hot,
+        coordinates="chr1:100-200:-",
+        zoom_n_bases=50,
+        x_shift=20,
+        show=False
+    )
+    assert fig is not None and ax is not None
+    plt.close()
+
 def test_patterns_contribution_scores_mutagenesis():
     scores = np.random.uniform(-3, 1, (1, 1, 100, 4))
     seqs_one_hot = np.eye(4)[None, np.random.randint(4, size=100)]


### PR DESCRIPTION
Previous coordinate logic depended on the zoom from zoom_n_bases being symmetric, as it just moved the start coordinate closer to the center by adding `start_idx`, and the end coordinate closer to the center by subtracting `start_idx`. That assumes the removed flank on both sides is identically sized, which breaks when you use `x_shift`. 

Theoretically I could also counteract this by saying `end = end - start_idx + 2*x_shift`, but that's less clean. I think just only doing the real coordinates adjustment with zoom and x_shift once (for `start`) is more robust, and then we just derive `end` from the shifted `start`. This does now mean we ignore the `end` from the provided coordinates, but that's a price I'm willing to pay.