### PR TITLE
Expand test suite

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,9 +10,11 @@
    - AnnDataWrapper should be slightly more memory-efficient.
 - Both AnnDataWrapper and AnnDataModule now now handle regions that could cross genome boundaries when stochastically shifted better. (#208)
 - Add tests for both AnnDataLoader and AnnDataWrapper, in both TensorFlow and PyTorch. (#208)
+- Added (more) tests for bigwig and bed reading, predictions from negative strand regions, classes for `contribution_scores`, and creating and loading models from the zoo. (#144, #233)
 
 ### Bugfixes
 - {func}`crested.pl.explain.contribution_scores`' argument `highlight_positions` now highlights [start, end) rather than [start, end], in order to align with indexing and `crested.tl.design`'s `protected_positions`.
+- {func}`crested.tl.zoo.basenji` can now be built again by fixing a renamed argument in `conv_block_bs`. (#144, #233)
 
 ### Dev/poweruser features
 - Added `BaseDataWrapper` and `BaseGenomicDataWrapper`, classes that form a base for all kinds of sequence-to-function training. They handle indexes, augmentation, sequence retrieval, iteration, etc. automatically, and leave you to adjust only the parts that matter in a modular fashion. (#208)

--- a/src/crested/tl/zoo/_basenji.py
+++ b/src/crested/tl/zoo/_basenji.py
@@ -87,6 +87,7 @@ def basenji(
         activation=activation,
         batch_norm=True,
         bn_momentum=0.9,
+        bn_sync=False,
     )
 
     current = conv_block_bs(

--- a/src/crested/tl/zoo/_basenji.py
+++ b/src/crested/tl/zoo/_basenji.py
@@ -97,6 +97,7 @@ def basenji(
         dropout=0.05,
         batch_norm=True,
         bn_momentum=0.9,
+        bn_sync=False,
     )
 
     current = keras.layers.GlobalAveragePooling1D()(current)

--- a/src/crested/tl/zoo/_basenji.py
+++ b/src/crested/tl/zoo/_basenji.py
@@ -70,7 +70,7 @@ def basenji(
         batch_norm=True,
         bn_momentum=0.9,
         bn_gamma=None,
-        bn_type="standard",
+        bn_sync=False,
         kernel_initializer="he_normal",
         padding="same",
     )

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,7 +1,6 @@
 import sys
 
 import numpy as np
-import pybigtools
 import pytest
 from anndata import AnnData
 
@@ -134,25 +133,6 @@ def test_import_bigwigs_full_chrom_mismatch_error(tmp_path):
         )
 
 
-def test_import_bigwigs_partial_chrom_mismatch_warning(tmp_path, capfd):
-    # A minority of regions on a chromosome absent from the bigwig should warn but still return values
-    mixed_bed = tmp_path / "mixed.bed"
-    with open(mixed_bed, "w") as f:
-        f.write("chr1\t3094805\t3095305\tr0\n")
-        for i in range(5):
-            f.write(f"chr2\t{1000 + i * 600}\t{1000 + i * 600 + 500}\tregion_{i}\n")
-
-    ann_data = crested.import_bigwigs(
-        bigwigs_folder=["tests/data/test_bigwigs/lamp5_sample.bw"],
-        regions_file=str(mixed_bed),
-    )
-    captured = capfd.readouterr()
-    assert "did not match chromosomes" in captured.err + captured.out
-    # All 6 regions are kept, but the 5 mismatched (chr2) ones are NaN-filled
-    assert ann_data.shape == (1, 6)
-    assert np.isnan(ann_data.X).sum() == 5
-
-
 def test_import_beds_chromsizes_mismatch_error(tmp_path):
     # A chromsizes file with no chromosomes in common with the regions file should raise
     bad_chromsizes = tmp_path / "bad.chrom.sizes"
@@ -165,24 +145,6 @@ def test_import_beds_chromsizes_mismatch_error(tmp_path):
             regions_file="tests/data/test.regions.bed",
             chromsizes_file=str(bad_chromsizes),
         )
-
-
-def test_import_bigwigs_negative_values_warning(tmp_path, capfd):
-    neg_bw_path = tmp_path / "neg.bw"
-    writer = pybigtools.open(str(neg_bw_path), "w")
-    writer.write(
-        {"chr1": 195471971},
-        [("chr1", 3094805, 3095305, -1.5), ("chr1", 3095470, 3095970, 2.0)],
-    )
-
-    ann_data = crested.import_bigwigs(
-        bigwigs_folder=[str(neg_bw_path)],
-        regions_file="tests/data/test_bigwigs/consensus_peaks_subset.bed",
-    )
-    captured = capfd.readouterr()
-    assert "contain negative values" in captured.err + captured.out
-    assert isinstance(ann_data, AnnData)
-
 
 def test_import_bigwigs_list_input():
     ann_data = crested.import_bigwigs(

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,6 +1,7 @@
 import sys
 
 import numpy as np
+import pybigtools
 import pytest
 from anndata import AnnData
 
@@ -117,3 +118,124 @@ def test_import_bigwigs_columns():
     assert "chr" in ann_data.var.columns
     assert "start" in ann_data.var.columns
     assert "end" in ann_data.var.columns
+
+
+def test_import_bigwigs_full_chrom_mismatch_error(tmp_path):
+    # All regions on a chromosome absent from the bigwig (only has chr1) should raise
+    bad_bed = tmp_path / "bad.bed"
+    with open(bad_bed, "w") as f:
+        for i in range(5):
+            f.write(f"chr2\t{1000 + i * 600}\t{1000 + i * 600 + 500}\tregion_{i}\n")
+
+    with pytest.raises(ValueError, match="All read-in values are NaNs"):
+        crested.import_bigwigs(
+            bigwigs_folder=["tests/data/test_bigwigs/lamp5_sample.bw"],
+            regions_file=str(bad_bed),
+        )
+
+
+def test_import_bigwigs_partial_chrom_mismatch_warning(tmp_path, capfd):
+    # A minority of regions on a chromosome absent from the bigwig should warn but still return values
+    mixed_bed = tmp_path / "mixed.bed"
+    with open(mixed_bed, "w") as f:
+        f.write("chr1\t3094805\t3095305\tr0\n")
+        for i in range(5):
+            f.write(f"chr2\t{1000 + i * 600}\t{1000 + i * 600 + 500}\tregion_{i}\n")
+
+    ann_data = crested.import_bigwigs(
+        bigwigs_folder=["tests/data/test_bigwigs/lamp5_sample.bw"],
+        regions_file=str(mixed_bed),
+    )
+    captured = capfd.readouterr()
+    assert "did not match chromosomes" in captured.err + captured.out
+    # All 6 regions are kept, but the 5 mismatched (chr2) ones are NaN-filled
+    assert ann_data.shape == (1, 6)
+    assert np.isnan(ann_data.X).sum() == 5
+
+
+def test_import_beds_chromsizes_mismatch_error(tmp_path):
+    # A chromsizes file with no chromosomes in common with the regions file should raise
+    bad_chromsizes = tmp_path / "bad.chrom.sizes"
+    with open(bad_chromsizes, "w") as f:
+        f.write("chrZZZ\t1000000\n")
+
+    with pytest.raises(ValueError, match="fell within known chromosomes"):
+        crested.import_beds(
+            beds_folder="tests/data/test_topics",
+            regions_file="tests/data/test.regions.bed",
+            chromsizes_file=str(bad_chromsizes),
+        )
+
+
+def test_import_bigwigs_negative_values_warning(tmp_path, capfd):
+    neg_bw_path = tmp_path / "neg.bw"
+    writer = pybigtools.open(str(neg_bw_path), "w")
+    writer.write(
+        {"chr1": 195471971},
+        [("chr1", 3094805, 3095305, -1.5), ("chr1", 3095470, 3095970, 2.0)],
+    )
+
+    ann_data = crested.import_bigwigs(
+        bigwigs_folder=[str(neg_bw_path)],
+        regions_file="tests/data/test_bigwigs/consensus_peaks_subset.bed",
+    )
+    captured = capfd.readouterr()
+    assert "contain negative values" in captured.err + captured.out
+    assert isinstance(ann_data, AnnData)
+
+
+def test_import_bigwigs_list_input():
+    ann_data = crested.import_bigwigs(
+        bigwigs_folder=[
+            "tests/data/test_bigwigs/lamp5_sample.bw",
+            "tests/data/test_bigwigs/vip_sample.bigwig",
+        ],
+        regions_file="tests/data/test_bigwigs/consensus_peaks_subset.bed",
+    )
+    assert list(ann_data.obs.index) == ["lamp5_sample", "vip_sample"]
+    assert ann_data.shape == (2, 5000)
+
+
+def test_import_bigwigs_dict_input():
+    ann_data = crested.import_bigwigs(
+        bigwigs_folder={
+            "MyLamp5": "tests/data/test_bigwigs/lamp5_sample.bw",
+            "MyVip": "tests/data/test_bigwigs/vip_sample.bigwig",
+        },
+        regions_file="tests/data/test_bigwigs/consensus_peaks_subset.bed",
+    )
+    assert list(ann_data.obs.index) == ["MyLamp5", "MyVip"]
+    assert ann_data.shape == (2, 5000)
+
+
+def test_import_beds_list_input():
+    ann_data = crested.import_beds(
+        beds_folder=[
+            "tests/data/test_topics/Topic_1.bed",
+            "tests/data/test_topics/Topic_2.bed",
+        ],
+        regions_file="tests/data/test.regions.bed",
+    )
+    assert list(ann_data.obs.index) == ["Topic_1", "Topic_2"]
+    assert ann_data.shape[0] == 2
+
+
+def test_import_beds_dict_input():
+    ann_data = crested.import_beds(
+        beds_folder={
+            "MyTopic1": "tests/data/test_topics/Topic_1.bed",
+            "MyTopic2": "tests/data/test_topics/Topic_2.bed",
+        },
+        regions_file="tests/data/test.regions.bed",
+    )
+    assert list(ann_data.obs.index) == ["MyTopic1", "MyTopic2"]
+    assert ann_data.shape[0] == 2
+
+
+def test_import_beds_list_input_classes_subset_rejected():
+    with pytest.raises(ValueError, match="classes_subset only works"):
+        crested.import_beds(
+            beds_folder=["tests/data/test_topics/Topic_1.bed"],
+            regions_file="tests/data/test.regions.bed",
+            classes_subset=["Topic_1"],
+        )

--- a/tests/test_pl.py
+++ b/tests/test_pl.py
@@ -457,6 +457,17 @@ def test_corr_violin(adata_preds):
     assert fig is not None and ax is not None
     plt.close()
 
+    # Plot a single model passed as a bare string, not a list
+    fig, ax = crested.pl.corr.violin(
+        adata=adata_preds,
+        model_names='model_1',
+        split=None,
+        show=False
+    )
+    assert isinstance(ax, plt.Axes)
+    assert fig is not None and ax is not None
+    plt.close()
+
 # ---------- Test dist -------------
 def test_dist_histogram(adata_preds):
     # Test simple plot

--- a/tests/test_tl.py
+++ b/tests/test_tl.py
@@ -81,6 +81,80 @@ def test_predict(keras_model, adata, genome):
     assert predictions == pytest.approx(predictions_pos)
     assert predictions != pytest.approx(predictions_neg)
 
+    # Predicting on a "-"-strand region must be numerically identical to
+    # independently reverse-complementing the "+" sequence and predicting on that directly
+    seq_pos = genome.fetch(region=region_str_pos)
+    seq_neg = crested.utils.reverse_complement(seq_pos)
+    predictions_seq_pos = crested.tl.predict(seq_pos, keras_model)
+    predictions_seq_neg = crested.tl.predict(seq_neg, keras_model)
+    assert predictions_pos == pytest.approx(predictions_seq_pos)
+    assert predictions_neg == pytest.approx(predictions_seq_neg)
+
+    # Same consistency check when regions come from an AnnData's var_names
+    adata_stranded = create_anndata_with_regions([region_str_pos, region_str_neg])
+    predictions_stranded = crested.tl.predict(
+        input=adata_stranded, model=keras_model, genome=genome
+    )
+    assert predictions_stranded[0] == pytest.approx(predictions_seq_pos[0])
+    assert predictions_stranded[1] == pytest.approx(predictions_seq_neg[0])
+
+
+def test_contribution_scores_target_idx(keras_model, genome):
+    sequence = "ATCGA" * 100
+
+    # np.int64 (e.g. from np.argmax()) should be accepted like a plain int
+    scores, one_hot_encoded_sequences = crested.tl.contribution_scores(
+        sequence,
+        target_idx=np.int64(1),
+        model=keras_model,
+        genome=genome,
+        method="integrated_grad",
+    )
+    assert scores.shape == (1, 1, 500, 4)
+    assert one_hot_encoded_sequences.shape == (1, 500, 4)
+
+    # None -> scores for all classes
+    scores, one_hot_encoded_sequences = crested.tl.contribution_scores(
+        sequence,
+        target_idx=None,
+        model=keras_model,
+        genome=genome,
+        method="integrated_grad",
+    )
+    assert scores.shape == (1, 5, 500, 4)
+
+    # Empty list -> scores for the 'combined' class
+    scores, one_hot_encoded_sequences = crested.tl.contribution_scores(
+        sequence,
+        target_idx=[],
+        model=keras_model,
+        genome=genome,
+        method="integrated_grad",
+        verbose=False,
+    )
+    assert scores.shape == (1, 1, 500, 4)
+
+    # A string is not a valid target_idx (should suggest anndata.obs_names.index) and should raise
+    with pytest.raises(ValueError, match="not a string"):
+        crested.tl.contribution_scores(
+            sequence,
+            target_idx="Topic_1",
+            model=keras_model,
+            genome=genome,
+            method="integrated_grad",
+        )
+
+    # Other invalid types should also raise a clear error
+    with pytest.raises(ValueError):
+        crested.tl.contribution_scores(
+            sequence,
+            target_idx=1.5,
+            model=keras_model,
+            genome=genome,
+            method="integrated_grad",
+        )
+
+
 def test_score_gene_locus(keras_model, genome):
     chrom = "chr1"
     start = 200000

--- a/tests/test_zoo.py
+++ b/tests/test_zoo.py
@@ -1,0 +1,45 @@
+"""Test that all crested.tl.zoo model architectures build and survive a save/load round trip."""
+
+import pytest
+
+import crested
+from crested.tl import zoo
+
+# Only seq_len/num_classes (which have no defaults) are overridden; all other
+# hyperparameters use the architecture's own defaults.
+ZOO_ARCHITECTURES = [
+    ("simple_convnet", zoo.simple_convnet, {"seq_len": 500, "num_classes": 2}),
+    ("basenji", zoo.basenji, {"seq_len": 131072, "num_classes": 2}),
+    ("deeptopic_cnn", zoo.deeptopic_cnn, {"seq_len": 500, "num_classes": 2}),
+    ("deeptopic_lstm", zoo.deeptopic_lstm, {"seq_len": 500, "num_classes": 2}),
+    ("dilated_cnn", zoo.dilated_cnn, {"seq_len": 2114, "num_classes": 2}),
+    (
+        "dilated_cnn_decoupled",
+        zoo.dilated_cnn_decoupled,
+        {"seq_len": 2114, "num_classes": 2},
+    ),
+    ("enformer", zoo.enformer, {"seq_len": 196608, "num_classes": 2}),
+    ("borzoi", zoo.borzoi, {"seq_len": 524288, "num_classes": 2}),
+    ("borzoi_prime", zoo.borzoi_prime, {"seq_len": 524288, "num_classes": 2}),
+]
+
+
+@pytest.mark.parametrize(
+    "factory, kwargs",
+    [(factory, kwargs) for _, factory, kwargs in ZOO_ARCHITECTURES],
+    ids=[name for name, _, _ in ZOO_ARCHITECTURES],
+)
+def test_zoo_model_save_load(factory, kwargs, tmp_path):
+    """All zoo architectures should build and their saved .keras file should load back via crested.utils.load_model.
+
+    Regression test for #141/#142: the custom attention layers (AttentionPool1D,
+    MultiheadAttention) used by enformer/borzoi/borzoi_prime previously failed to
+    deserialize because they lacked @keras.saving.register_keras_serializable().
+    """
+    model = factory(**kwargs)
+    model_path = tmp_path / "model.keras"
+    model.save(model_path)
+
+    loaded_model = crested.utils.load_model(model_path)
+
+    assert loaded_model.output_shape == model.output_shape


### PR DESCRIPTION
Add a bunch of tests as described in #155. Some of those we got in the meantime, but these fill some gaps and notably also test intended failures. 

Also fixes a bug in (unused) `tl.zoo.basenji` architecture.