### PR TITLE
Add simple resizing function

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -18,6 +18,7 @@
 ### Bugfixes
 - {func}`crested.pl.explain.contribution_scores`' argument `highlight_positions` now highlights [start, end) rather than [start, end], in order to align with indexing and `crested.tl.design`'s `protected_positions`.
 - {func}`crested.tl.zoo.basenji` can now be built again by fixing a renamed argument in `conv_block_bs`. (#144, #233)
+- {func}`crested.utils.parse_region` now also handles negative coordinates. (#234)
 
 ### Dev/poweruser features
 - Added `BaseDataWrapper` and `BaseGenomicDataWrapper`, classes that form a base for all kinds of sequence-to-function training. They handle indexes, augmentation, sequence retrieval, iteration, etc. automatically, and leave you to adjust only the parts that matter in a modular fashion. (#208)

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,7 +10,10 @@
    - AnnDataWrapper should be slightly more memory-efficient.
 - Both AnnDataWrapper and AnnDataModule now now handle regions that could cross genome boundaries when stochastically shifted better. (#208)
 - Add tests for both AnnDataLoader and AnnDataWrapper, in both TensorFlow and PyTorch. (#208)
-- Added (more) tests for bigwig and bed reading, predictions from negative strand regions, classes for `contribution_scores`, and creating and loading models from the zoo. (#144, #233)
+- Added {func}`crested.utils.resize_region` (#160, #234)
+- Added (more) tests:
+  - bigwig and bed reading, predictions from negative strand regions, classes for `contribution_scores`, and creating and loading models from the zoo. (#144, #233)
+  - `utils.parse_region` and `utils.resize_region` (#234)
 
 ### Bugfixes
 - {func}`crested.pl.explain.contribution_scores`' argument `highlight_positions` now highlights [start, end) rather than [start, end], in order to align with indexing and `crested.tl.design`'s `protected_positions`.

--- a/src/crested/pp/_regions.py
+++ b/src/crested/pp/_regions.py
@@ -17,9 +17,7 @@ from crested.utils._logging import log_and_raise
 
 def _read_chromsizes(chromsizes_file: str | PathLike) -> dict[str, int]:
     """Read chromsizes file into a dictionary."""
-    chromsizes = pd.read_csv(
-        chromsizes_file, sep="\t", header=None, names=["chr", "size"]
-    )
+    chromsizes = pd.read_csv(chromsizes_file, sep="\t", header=None, names=["chr", "size"])
     chromsizes_dict = chromsizes.set_index("chr")["size"].to_dict()
     return chromsizes_dict
 
@@ -38,6 +36,8 @@ def change_regions_width(
     This function is useful when you want to train on a wider/narrower region than the
     original consensus regions.
 
+    To resize individual regions quickly, please use :func:`~crested.utils.resize_region` instead.
+
     Parameters
     ----------
     adata
@@ -54,6 +54,10 @@ def change_regions_width(
     -------
     If `inplace=True` (default), modifies the anndata in-place and doesn't return anything.
     If `inplace=False`, returns the AnnData object with the modified regions.
+
+    See Also
+    --------
+    crested.utils.resize_region
 
     Example
     -------
@@ -85,9 +89,9 @@ def change_regions_width(
     else:
         chromsizes = None
 
-    if adata.var_names[0].count(':') == 1:
+    if adata.var_names[0].count(":") == 1:
         stranded = False
-    elif adata.var_names[0].count(':') == 2:
+    elif adata.var_names[0].count(":") == 2:
         stranded = True
     else:
         raise ValueError("Region names must follow 'chr:start-end' or 'chr:start-end:strand' layout.")
@@ -104,9 +108,9 @@ def change_regions_width(
     for region_name in adata.var_names:
         # Resize regions
         chrom, start, end, strand = parse_region(region_name)
-        center = (start + end)/2
-        new_start, new_end = int(center-half_width), int(center+half_width)
-        new_name = f"{chrom}:{int(center-half_width)}-{int(center+half_width)}"
+        center = (start + end) / 2
+        new_start, new_end = int(center - half_width), int(center + half_width)
+        new_name = f"{chrom}:{int(center - half_width)}-{int(center + half_width)}"
         if stranded:
             new_name += f":{strand}"
         new_starts.append(new_start)
@@ -125,10 +129,10 @@ def change_regions_width(
                 regions_to_keep.append(new_name)
 
     # Set new values in adata
-    adata.var['unresized_index'] = adata.var_names
+    adata.var["unresized_index"] = adata.var_names
     adata.var.index = new_names
-    adata.var['start'] = new_starts
-    adata.var['end'] = new_ends
+    adata.var["start"] = new_starts
+    adata.var["end"] = new_ends
     adata.var_names.name = "region"
 
     # Filter out oversized regions
@@ -137,7 +141,6 @@ def change_regions_width(
             adata._inplace_subset_var(regions_to_keep)
         else:
             adata = adata[:, regions_to_keep].copy()
-
 
     if not inplace:
         return adata

--- a/src/crested/pp/_regions.py
+++ b/src/crested/pp/_regions.py
@@ -11,7 +11,7 @@ from loguru import logger
 
 from crested import Genome
 from crested import _conf as conf
-from crested.utils import parse_region
+from crested.utils import parse_region, resize_region
 from crested.utils._logging import log_and_raise
 
 
@@ -89,50 +89,30 @@ def change_regions_width(
     else:
         chromsizes = None
 
-    if adata.var_names[0].count(":") == 1:
-        stranded = False
-    elif adata.var_names[0].count(":") == 2:
-        stranded = True
-    else:
-        raise ValueError("Region names must follow 'chr:start-end' or 'chr:start-end:strand' layout.")
-
     # Copy if doing inplace
     if not inplace:
         adata = adata.copy()
     adata.var = adata.var.copy()
 
     # Create new values and record spacing for all regions
-    half_width = width / 2
-    new_starts, new_ends, new_names = [], [], []
-    regions_to_keep = []
-    for region_name in adata.var_names:
-        # Resize regions
-        chrom, start, end, strand = parse_region(region_name)
-        center = (start + end) / 2
-        new_start, new_end = int(center - half_width), int(center + half_width)
-        new_name = f"{chrom}:{int(center - half_width)}-{int(center + half_width)}"
-        if stranded:
-            new_name += f":{strand}"
-        new_starts.append(new_start)
-        new_ends.append(new_end)
-        new_names.append(new_name)
-
-        # Check chromosome boundaries on the resized coordinates (not the
-        # originals): a region whose centered/widened window runs off a contig
-        # edge must be dropped even if the original peak was in-bounds.
-        if chromsizes is not None:
+    new_regions = resize_region(adata.var_names)
+    new_parsed_regions = [parse_region(region) for region in new_regions] # Parse again to also have access to start/end
+    if chromsizes is not None:
+        regions_to_keep = []
+        for new_region_str, new_region_tuple in zip(new_regions, new_parsed_regions, strict=True):
+            chrom, new_start, new_end, strand = new_region_tuple
             if new_start < 0 or new_end > chromsizes.get(chrom, float("inf")):
                 logger.warning(
-                    f"Region {region_name} with new coordinates {chrom}:{new_start}-{new_end} is out of bounds for chromosome {chrom}. Removing region."
+                    f"Region {new_region_str} with new coordinates {chrom}:{new_start}-{new_end} is out of bounds for chromosome {chrom}. Removing region."
                 )
             else:
-                regions_to_keep.append(new_name)
+                regions_to_keep.append(new_region_str)
 
     # Set new values in adata
     adata.var["unresized_index"] = adata.var_names
-    adata.var.index = new_names
-    adata.var["start"] = new_starts
-    adata.var["end"] = new_ends
+    adata.var.index = new_regions
+    adata.var["start"] = [parsed_region[1] for parsed_region in new_parsed_regions]
+    adata.var["end"] = [parsed_region[2] for parsed_region in new_parsed_regions]
     adata.var_names.name = "region"
 
     # Filter out oversized regions

--- a/src/crested/pp/_regions.py
+++ b/src/crested/pp/_regions.py
@@ -95,8 +95,8 @@ def change_regions_width(
     adata.var = adata.var.copy()
 
     # Create new values and record spacing for all regions
-    new_regions = resize_region(adata.var_names)
-    new_parsed_regions = [parse_region(region) for region in new_regions] # Parse again to also have access to start/end
+    new_regions = resize_region(adata.var_names, width)
+    new_parsed_regions = [parse_region(region) for region in new_regions]  # Parse again to access start/end
     if chromsizes is not None:
         regions_to_keep = []
         for new_region_str, new_region_tuple in zip(new_regions, new_parsed_regions, strict=True):

--- a/src/crested/utils/__init__.py
+++ b/src/crested/utils/__init__.py
@@ -2,20 +2,13 @@
 
 from ._logging import setup_logging
 from ._model_utils import load_model, permute_model
-from ._old import (
-    EnhancerOptimizer,
-    derive_intermediate_sequences,
-)
+from ._old import EnhancerOptimizer, derive_intermediate_sequences
 from ._seq_utils import (
     flip_region_strand,
     hot_encoding_to_sequence,
     one_hot_encode_sequence,
     parse_region,
+    resize_region,
     reverse_complement,
 )
-from ._utils import (
-    calculate_nucleotide_distribution,
-    fetch_sequences,
-    read_bigwig_region,
-)
-
+from ._utils import calculate_nucleotide_distribution, fetch_sequences, read_bigwig_region

--- a/src/crested/utils/_seq_utils.py
+++ b/src/crested/utils/_seq_utils.py
@@ -281,10 +281,15 @@ def parse_region(region: tuple[str, int, int] | tuple[str, int, int, str] | str)
                 raise ValueError(
                     f"Expect region with pattern chr:start-end:strand or chr:start-end, not {region}"
                 ) from None
-            if start_end.count("-") == 1:
+            try:
                 start, end = map(int, start_end.split("-"))
-            else:
-                start, end = map(int, re.match(r"(-?\d)-(-?\d)", start_end).groups())
+            except ValueError:
+                try:
+                    start, end = map(int, re.match(r"(-?\d+)-(-?\d+)", start_end).groups())
+                except ValueError as err:
+                    raise ValueError(
+                    f"Expect region with pattern chr:start-end:strand or chr:start-end, not {region}"
+                ) from err
         else:
             raise ValueError(
                 f"Expect region to be formatted as a 'chr:start-end[:string]' string or (chr, start, end[, string]) tuple, not {region}"

--- a/src/crested/utils/_seq_utils.py
+++ b/src/crested/utils/_seq_utils.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Sequence
+
 import numpy as np
 
 
@@ -284,3 +286,55 @@ def parse_region(region: tuple[str, int, int] | tuple[str, int, int, str] | str)
                 f"Expect region to be formatted as a 'chr:start-end[:string]' string or (chr, start, end[, string]) tuple, not {region}"
             ) from None
         return chrom, start, end, strand
+
+
+def resize_region(
+    region: tuple[str, int, int] | tuple[str, int, int, str] | str | Sequence, width: int
+) -> tuple[str, int, int] | tuple[str, int, int, str] | str | list:
+    """Resize a region or list of regions to the new desired width.
+
+    Parameters
+    ----------
+    region
+        A region strand (`'chr:start-end'` or `'chr:start-end:strand'`), region tuple (`(chrom, start, end)` or `(chrom, start, end, strand)`), or a sequence of them.
+    width
+        The width to resize to.
+
+    Returns
+    -------
+    The resized region(s), in the same shape as originally provided.
+    """
+    # Check shape: detect region by being str or tuple and having first element (either first letter or chrom in tuple) be str to make sure it's always a list we can loop over
+    if isinstance(region, (str, tuple)) and isinstance(region[0], str):
+        is_single_region = True
+        region = [region]
+    elif isinstance(region[0], (str, tuple)) and isinstance(region[0][0], str):
+        is_single_region = False
+    else:
+        raise ValueError("`region` must be a single string or tuple, or a list of strings/tuples denoting regions.")
+
+    # Start looping over list
+    resized_regions = []
+    half_width = width / 2
+    for individual_region in region:
+        # Actually parse region and resize
+        chrom, start, end, strand = parse_region(individual_region)
+        center = (start + end) // 2
+        new_start, new_end = int(center - half_width), int(center + half_width)
+
+        # Check type and strandedness and use to recreate region
+        if isinstance(individual_region, str):
+            new_region = f"{chrom}:{new_start}-{new_end}"
+            if individual_region.count(":") == 2:
+                new_region += f":{strand}"
+        elif isinstance(individual_region, tuple):
+            if len(individual_region) == 3:
+                new_region = (chrom, new_start, new_end)
+            elif len(individual_region) == 4:
+                new_region = (chrom, new_start, new_end, strand)
+        resized_regions.append(new_region)
+
+    if is_single_region:
+        return resized_regions[0]
+    else:
+        return resized_regions

--- a/src/crested/utils/_seq_utils.py
+++ b/src/crested/utils/_seq_utils.py
@@ -16,18 +16,12 @@ def get_hot_encoding_table(
         return np.frombuffer(string.encode("ascii"), dtype=np.uint8)
 
     # 256 x 4
-    hot_encoding_table = np.zeros(
-        (np.iinfo(np.uint8).max + 1, len(alphabet)), dtype=dtype
-    )
+    hot_encoding_table = np.zeros((np.iinfo(np.uint8).max + 1, len(alphabet)), dtype=dtype)
 
     # For each ASCII value of the nucleotides used in the alphabet
     # (upper and lower case), set 1 in the correct column.
-    hot_encoding_table[str_to_uint8(alphabet.upper())] = np.eye(
-        len(alphabet), dtype=dtype
-    )
-    hot_encoding_table[str_to_uint8(alphabet.lower())] = np.eye(
-        len(alphabet), dtype=dtype
-    )
+    hot_encoding_table[str_to_uint8(alphabet.upper())] = np.eye(len(alphabet), dtype=dtype)
+    hot_encoding_table[str_to_uint8(alphabet.lower())] = np.eye(len(alphabet), dtype=dtype)
 
     # For each ASCII value of the nucleotides used in the neutral alphabet
     # (upper and lower case), set neutral_value in the correct column.
@@ -64,9 +58,7 @@ def one_hot_encode_sequence(sequence: str, expand_dim: bool = True) -> np.ndarra
             axis=0,
         )
     else:
-        return HOT_ENCODING_TABLE[
-            np.frombuffer(sequence.encode("ascii"), dtype=np.uint8)
-        ]
+        return HOT_ENCODING_TABLE[np.frombuffer(sequence.encode("ascii"), dtype=np.uint8)]
 
 
 def generate_mutagenesis(x, include_original=True, flanks=(0, 0), protected_positions=None):
@@ -103,9 +95,7 @@ def generate_motif_insertions(x, motif, flanks=(0, 0), masked_locations=None):
     for motif_start in range(start, end):
         motif_end = motif_start + motif_length
         if masked_locations is not None:
-            if np.any(
-                (motif_start <= masked_locations) & (masked_locations < motif_end)
-            ):
+            if np.any((motif_start <= masked_locations) & (masked_locations < motif_end)):
                 continue
         x_new = np.copy(x)
         x_new[0, motif_start:motif_end, :] = motif
@@ -115,9 +105,7 @@ def generate_motif_insertions(x, motif, flanks=(0, 0), masked_locations=None):
     return np.concatenate(x_mut, axis=0), insertion_locations
 
 
-def generate_window_shuffle(
-    x, window_size, n_shuffles, uniform, include_original=True, flanks=(0, 0)
-):
+def generate_window_shuffle(x, window_size, n_shuffles, uniform, include_original=True, flanks=(0, 0)):
     """Generate all possible single point mutations in a sequence."""
     _, L, A = x.shape
     start, end = 0, L
@@ -130,9 +118,7 @@ def generate_window_shuffle(
         for location in range(start, end):
             x_new = np.copy(x)
             if uniform:
-                x_new[0, location : location + window_size, :] = rng.choice(
-                    uniform_array, window_size
-                )
+                x_new[0, location : location + window_size, :] = rng.choice(uniform_array, window_size)
             else:
                 rng.shuffle(x_new[0, location : location + window_size, :], axis=0)
             x_mut.append(x_new)
@@ -141,9 +127,7 @@ def generate_window_shuffle(
 
 def build_one_hot_decoding_table() -> np.ndarray:
     """Get hot decoding table to decode a one hot encoded sequence to a DNA sequence string."""
-    one_hot_decoding_table = np.full(
-        np.iinfo(np.uint8).max + 1, ord("N"), dtype=np.uint8
-    )
+    one_hot_decoding_table = np.full(np.iinfo(np.uint8).max + 1, ord("N"), dtype=np.uint8)
     one_hot_decoding_table[1] = ord("A")
     one_hot_decoding_table[2] = ord("C")
     one_hot_decoding_table[4] = ord("G")
@@ -180,18 +164,10 @@ def hot_encoding_to_sequence(one_hot_encoded_sequence: np.ndarray) -> str:
     sequence = (
         HOT_DECODING_TABLE[
             (
-                (
-                    hes_u32 << 31 >> 31
-                )  # A: 2^0  : 1        -> 1 = A in HOT_DECODING_TABLE
-                | (
-                    hes_u32 << 23 >> 30
-                )  # C: 2^8  : 256      -> 2 = C in HOT_DECODING_TABLE
-                | (
-                    hes_u32 << 15 >> 29
-                )  # G: 2^16 : 65536    -> 4 = G in HOT_DECODING_TABLE
-                | (
-                    hes_u32 << 7 >> 28
-                )  # T: 2^24 : 16777216 -> 8 = T in HOT_DECODING_TABLE
+                (hes_u32 << 31 >> 31)  # A: 2^0  : 1        -> 1 = A in HOT_DECODING_TABLE
+                | (hes_u32 << 23 >> 30)  # C: 2^8  : 256      -> 2 = C in HOT_DECODING_TABLE
+                | (hes_u32 << 15 >> 29)  # G: 2^16 : 65536    -> 4 = G in HOT_DECODING_TABLE
+                | (hes_u32 << 7 >> 28)  # T: 2^24 : 16777216 -> 8 = T in HOT_DECODING_TABLE
             ).astype(np.uint8)
         ]
         .tobytes()
@@ -230,24 +206,19 @@ def reverse_complement(sequence: str | list[str] | np.ndarray) -> str | np.ndarr
             elif sequence.shape[0] == 4:
                 return sequence[:, ::-1][:, ::-1]
             else:
-                raise ValueError(
-                    "One-hot encoded array must have shape (W, 4) or (4, W)"
-                )
+                raise ValueError("One-hot encoded array must have shape (W, 4) or (4, W)")
         elif sequence.ndim == 3:
             if sequence.shape[1] == 4:
                 return sequence[:, ::-1, ::-1]
             elif sequence.shape[2] == 4:
                 return sequence[:, ::-1, ::-1]
             else:
-                raise ValueError(
-                    "One-hot encoded array must have shape (B, 4, W) or (B, W, 4)"
-                )
+                raise ValueError("One-hot encoded array must have shape (B, 4, W) or (B, W, 4)")
         else:
             raise ValueError("One-hot encoded array must have 2 or 3 dimensions")
     else:
-        raise TypeError(
-            "Input must be either a DNA sequence string or a one-hot encoded array"
-        )
+        raise TypeError("Input must be either a DNA sequence string or a one-hot encoded array")
+
 
 def flip_region_strand(region: str | tuple[str, int, int, str]) -> str | tuple[str, int, int, str]:
     """Reverse the strand of a region strand or tuple.
@@ -266,6 +237,7 @@ def flip_region_strand(region: str | tuple[str, int, int, str]) -> str | tuple[s
         return region[:-1] + strand_reverser[region[-1]]
     except TypeError:
         return region[:-1] + tuple(strand_reverser[region[-1]])
+
 
 def parse_region(region: tuple[str, int, int] | tuple[str, int, int, str] | str) -> tuple[str, int, int, str]:
     """Parse a region string or tuple, returning a consistent `(chr, start, end, strand)` tuple.
@@ -292,17 +264,23 @@ def parse_region(region: tuple[str, int, int] | tuple[str, int, int, str] | str)
                 chrom, start, end = region
                 strand = "+"
             except ValueError as err:
-                raise ValueError(f"Expect region with pattern (chr, start, end, strand) or (chr, start, end), not {region}") from err
+                raise ValueError(
+                    f"Expect region with pattern (chr, start, end, strand) or (chr, start, end), not {region}"
+                ) from err
         elif isinstance(region, str):
-            region_split = region.split(':')
+            region_split = region.split(":")
             if len(region_split) == 3:
                 chrom, start_end, strand = region_split
             elif len(region_split) == 2:
                 chrom, start_end = region_split
                 strand = "+"
             else:
-                raise ValueError(f"Expect region with pattern chr:start-end:strand or chr:start-end, not {region}") from None
-            start, end = map(int, start_end.split('-'))
+                raise ValueError(
+                    f"Expect region with pattern chr:start-end:strand or chr:start-end, not {region}"
+                ) from None
+            start, end = map(int, start_end.split("-"))
         else:
-            raise ValueError(f"Expect region to be formatted as a 'chr:start-end[:string]' string or (chr, start, end[, string]) tuple, not {region}") from None
+            raise ValueError(
+                f"Expect region to be formatted as a 'chr:start-end[:string]' string or (chr, start, end[, string]) tuple, not {region}"
+            ) from None
         return chrom, start, end, strand

--- a/src/crested/utils/_seq_utils.py
+++ b/src/crested/utils/_seq_utils.py
@@ -293,6 +293,8 @@ def resize_region(
 ) -> tuple[str, int, int] | tuple[str, int, int, str] | str | list:
     """Resize a region or list of regions to the new desired width.
 
+    To resize an entire AnnData, please use :func:`~crested.pp.change_regions_width` instead.
+
     Parameters
     ----------
     region
@@ -303,6 +305,10 @@ def resize_region(
     Returns
     -------
     The resized region(s), in the same shape as originally provided.
+
+    See Also
+    --------
+    crested.pp.change_regions_width
     """
     # Check shape: detect region by being str or tuple and having first element (either first letter or chrom in tuple) be str to make sure it's always a list we can loop over
     if isinstance(region, (str, tuple)) and isinstance(region[0], str):

--- a/src/crested/utils/_seq_utils.py
+++ b/src/crested/utils/_seq_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from collections.abc import Sequence
 
 import numpy as np
@@ -280,7 +281,10 @@ def parse_region(region: tuple[str, int, int] | tuple[str, int, int, str] | str)
                 raise ValueError(
                     f"Expect region with pattern chr:start-end:strand or chr:start-end, not {region}"
                 ) from None
-            start, end = map(int, start_end.split("-"))
+            if start_end.count("-") == 1:
+                start, end = map(int, start_end.split("-"))
+            else:
+                start, end = map(int, re.match(r"(-?\d)-(-?\d)").groups())
         else:
             raise ValueError(
                 f"Expect region to be formatted as a 'chr:start-end[:string]' string or (chr, start, end[, string]) tuple, not {region}"

--- a/src/crested/utils/_seq_utils.py
+++ b/src/crested/utils/_seq_utils.py
@@ -284,7 +284,7 @@ def parse_region(region: tuple[str, int, int] | tuple[str, int, int, str] | str)
             if start_end.count("-") == 1:
                 start, end = map(int, start_end.split("-"))
             else:
-                start, end = map(int, re.match(r"(-?\d)-(-?\d)").groups())
+                start, end = map(int, re.match(r"(-?\d)-(-?\d)", start_end).groups())
         else:
             raise ValueError(
                 f"Expect region to be formatted as a 'chr:start-end[:string]' string or (chr, start, end[, string]) tuple, not {region}"

--- a/tests/test_pp.py
+++ b/tests/test_pp.py
@@ -160,6 +160,10 @@ def test_change_regions_width_inplace(adata_function):
     assert not adata_function.var.equals(adata_inplace.var)
     assert not adata_function.var.equals(adata_copy.var)
 
+def test_change_regions_width(adata):
+    adata_resized = crested.pp.change_regions_width(adata, width=888, inplace=False)
+    assert adata_resized.var_names[0] == crested.utils.resize_region(adata.var_names[0], 888)
+    assert adata_resized.var_names[0] == "chr1:194207838-194208726"
 
 def test_change_regions_width_drops_resized_out_of_bounds():
     """Regions whose *resized* window falls off a contig edge must be dropped.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from crested.utils import (
     calculate_nucleotide_distribution,
     hot_encoding_to_sequence,
     one_hot_encode_sequence,
+    resize_region,
     reverse_complement,
 )
 
@@ -65,3 +66,28 @@ def test_nucleotide_distribution_unequal_inputs():
     seq = ["ACTTG", "AATTG", "A"]
     with pytest.raises(ValueError):
         _ = calculate_nucleotide_distribution(seq, per_position=True)
+
+
+def test_resize_region():
+    # Check single region entries
+    assert resize_region("chr1:100-200", 50) == "chr1:125-175"
+    assert resize_region(("chr1", 100, 200), 50) == ("chr1", 125, 175)
+
+    # Check multi-region entries
+    assert resize_region(["chr1:100-200", "chr15:5236-5238"], 50) == ["chr1:125-175", "chr15:5212-5262"]
+    assert resize_region([("chr1", 100, 200), ("chr15", 5236, 5238)], 50) == [("chr1", 125, 175), ("chr15", 5212, 5262)]
+
+    # Check stranded regions
+    assert resize_region(["chr1:100-200:+", "chr15:5236-5238:-"], 50) == ["chr1:125-175:+", "chr15:5212-5262:-"]
+    assert resize_region([("chr1", 100, 200, "+"), ("chr15", 5236, 5238, "-")], 50) == [
+        ("chr1", 125, 175, "+"),
+        ("chr15", 5212, 5262, "-"),
+    ]
+
+    # Check broken regions
+    with pytest.raises(ValueError):
+        resize_region("chr1;100_200", 50)
+    with pytest.raises(ValueError):
+        resize_region("chr1:100-200:+:hi", 50)
+    with pytest.raises(ValueError):
+        resize_region(("chr1", 100, 200, "+", "hi"), 50)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,6 +5,7 @@ from crested.utils import (
     calculate_nucleotide_distribution,
     hot_encoding_to_sequence,
     one_hot_encode_sequence,
+    parse_region,
     resize_region,
     reverse_complement,
 )
@@ -68,6 +69,25 @@ def test_nucleotide_distribution_unequal_inputs():
         _ = calculate_nucleotide_distribution(seq, per_position=True)
 
 
+def test_parse_region():
+    # Check unstranded string
+    assert parse_region("chr1:100-200") == ("chr1", 100, 200, "+")
+    # Check stranded string
+    assert parse_region("chr1:100-200:-") == ("chr1", 100, 200, "-")
+    # Check unstranded tuple
+    assert parse_region(("chr1", 100, 200)) == ("chr1", 100, 200, "+")
+    # Check stranded tuple
+    assert parse_region(("chr1", 100, 200, "-")) == ("chr1", 100, 200, "-")
+
+    # Check broken examples
+    with pytest.raises(ValueError):
+        parse_region("chr1;100_200")
+    with pytest.raises(ValueError):
+        parse_region("chr1:100-200:+:hi")
+    with pytest.raises(ValueError):
+        parse_region(("chr1", 100, 200, "+", "hi"))
+
+
 def test_resize_region():
     # Check single region entries
     assert resize_region("chr1:100-200", 50) == "chr1:125-175"
@@ -79,10 +99,7 @@ def test_resize_region():
 
     # Check stranded regions
     assert resize_region(["chr1:100-200:+", "chr15:5236-5238:-"], 50) == ["chr1:125-175:+", "chr15:5212-5262:-"]
-    assert resize_region([("chr1", 100, 200, "+"), ("chr15", 5236, 5238, "-")], 50) == [
-        ("chr1", 125, 175, "+"),
-        ("chr15", 5212, 5262, "-"),
-    ]
+    assert resize_region([("chr1", 100, 200, "+"), ("chr15", 5236, 5238, "-")], 50) == [("chr1", 125, 175, "+"), ("chr15", 5212, 5262, "-")]
 
     # Check broken regions
     with pytest.raises(ValueError):


### PR DESCRIPTION
Adds `crested.utils.resize_region`, which takes a single region or list of regions and changes them to your desired size.
Also has tests, and adds tests for `utils.parse_region` and `pp.change_regions_width` while we're at it. 

Note that this adds `resize_region` as a backend for `pp.change_regions_width`, which simplifies that function and removes code duplication. It does come at a cost of speed, since we now parse all regions twice (once during the resizing and again to get the starts and ends to save in the anndata), where previously we only needed to do that once. I think the extra time is small enough that it's worth the simplification, but I'm open to arguments to reverse it. 
 
Closes #160.  