### PR TITLE
Mutagenesis speedup

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,10 @@
 # Release notes
 
+## Unreleased
+
+### Bugfixes
+- Mutagenesis with {func}`crested.tl.contribution_scores` now doesn't predict the original sequence for every position in the sequence anymore, reducing the number of predictions needed by 25%. (#242)
+
 ## v1.10.0
 
 ### Features

--- a/src/crested/tl/_explainer.py
+++ b/src/crested/tl/_explainer.py
@@ -247,6 +247,7 @@ def mutagenesis(
 
         mut_score = np.zeros((1, len(class_index), L, A))
         k = 0
+        # Assumes predictions are from generate_mutagenesis(include_original=False) sequences
         for length in range(L):
             for a in range(A):
                 # If original seq is 1, it's wildtype and we use the wt score
@@ -272,7 +273,7 @@ def mutagenesis(
         # generate mutagenized sequences, skipping the redundant substitution back to the wildtype base
         x_mut = generate_mutagenesis(x, include_original=False)
 
-        # get baseline wildtype score
+        # predict for wildtype and mutagenized sequences
         wt_score = get_score(x, model, class_index, batch_size=batch_size)
         predictions = get_score(x_mut, model, class_index, batch_size=batch_size)
 
@@ -280,8 +281,10 @@ def mutagenesis(
         mut_score = reconstruct_map(predictions, wt_score)
         wt_score = wt_score[:, :, None, None]  # (1, n_classes) -> (1, n_classes, 1, 1) to broadcast over (L, A)
 
-        # Remove 1-length class index if not multi-class
+        # Calculate difference between wildtype and ref for every position and nucleotide
         score_diff = mut_score - wt_score
+
+        # Remove 1-length class index if not multi-class
         if not is_multi_class:
             score_diff = score_diff.squeeze(axis=1)
         scores.append(score_diff)

--- a/src/crested/tl/_explainer.py
+++ b/src/crested/tl/_explainer.py
@@ -260,6 +260,8 @@ def mutagenesis(
 
     def get_score(x, model, class_index, batch_size=None):
         predictions = model.predict(x, verbose=0, batch_size=batch_size)
+        if predictions.ndim == 1:
+            predictions = predictions[:, None]
         cols = [np.sqrt(np.sum(predictions**2, axis=-1)) if idx is None else predictions[:, idx] for idx in class_index]
         return np.stack(cols, axis=1)
 
@@ -342,6 +344,8 @@ def window_shuffle(
 
     def get_score(x, model, class_index, batch_size=None):
         predictions = model.predict(x, verbose=0, batch_size=batch_size)
+        if predictions.ndim == 1:
+            predictions = predictions[:, None]
         cols = [np.sqrt(np.sum(predictions**2, axis=-1)) if idx is None else predictions[:, idx] for idx in class_index]
         return np.stack(cols, axis=1)
 

--- a/src/crested/tl/_explainer.py
+++ b/src/crested/tl/_explainer.py
@@ -242,15 +242,20 @@ def mutagenesis(
     if not is_multi_class:
         class_index = [class_index]
 
-    def reconstruct_map(predictions):
+    def reconstruct_map(predictions, wt_score):
         _, L, A = x.shape
 
         mut_score = np.zeros((1, len(class_index), L, A))
         k = 0
         for length in range(L):
             for a in range(A):
-                mut_score[0, :, length, a] = predictions[k]
-                k += 1
+                # If original seq is 1, it's wildtype and we use the wt score
+                if x[0, length, a] == 1:
+                    mut_score[0, :, length, a] = wt_score[0, :]
+                # Else use the mutagenized score
+                else:
+                    mut_score[0, :, length, a] = predictions[k]
+                    k += 1
         return mut_score
 
     def get_score(x, model, class_index, batch_size=None):
@@ -262,15 +267,15 @@ def mutagenesis(
     for x in X:
         x = np.expand_dims(x, axis=0)
 
-        # generate mutagenized sequences
-        x_mut = generate_mutagenesis(x)
+        # generate mutagenized sequences, skipping the redundant substitution back to the wildtype base
+        x_mut = generate_mutagenesis(x, include_original=False)
 
         # get baseline wildtype score
         wt_score = get_score(x, model, class_index, batch_size=batch_size)
         predictions = get_score(x_mut, model, class_index, batch_size=batch_size)
 
         # reshape mutagenesis predictions
-        mut_score = reconstruct_map(predictions)
+        mut_score = reconstruct_map(predictions, wt_score)
         wt_score = wt_score[:, :, None, None]  # (1, n_classes) -> (1, n_classes, 1, 1) to broadcast over (L, A)
 
         # Remove 1-length class index if not multi-class


### PR DESCRIPTION
`method='mutagenesis'` in `tl.contribution_scores` was including the original in the mutagenized sequences for every position. There's no need for that, since we can just predict the original once and compare to it (and in fact, we do already predict the original separately anyway). Dropping these useless original sequences reduces the # of predictions per sequence from 4*L+1 to 3*L+1, so this should be a ~25% speedup.